### PR TITLE
Minimalist header menus and light-mode contrast improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import MapView from './components/MapView'
 import SummaryDashboard from './components/SummaryDashboard'
 import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
+import HeaderMenus from './components/HeaderMenus'
 
 // ── Dark mode ──────────────────────────────────────────────────────────────
 function useDarkMode() {
@@ -345,42 +346,17 @@ export default function App() {
             )}
           </div>
           <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
-            <button
-              onClick={() => setShowCollab(true)}
-              data-testid="share-button"
-              className="text-sm border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-400 dark:text-gray-500 flex items-center gap-1.5"
-            >
-              {collab.isCollaborating && (
-                <span
-                  className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ background: { syncing: '#f59e0b', synced: '#22c55e', error: '#ef4444' }[collab.syncStatus] ?? '#9ca3af' }}
-                  data-testid="sync-status-dot"
-                />
-              )}
-              Share
-            </button>
-            {hasData && (
-              <button
-                onClick={() => setShowExport(true)}
-                className="text-sm border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-400 dark:text-gray-500 flex items-center gap-1.5"
-              >↑ Export</button>
-            )}
-            <button
-              onClick={() => setModal({ type: 'transport', editing: null })}
-              className="text-sm border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 flex items-center gap-1.5"
-            >
-              <TransportIcon type="flight" size={13} color="#9ca3af" /> Add transport
-            </button>
-            <button
-              onClick={() => setModal({ type: 'hotel', editing: null })}
-              className="text-sm border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 flex items-center gap-1.5"
-            >
-              <BedIcon size={13} color="#9ca3af" /> Add hotel
-            </button>
-            <button
-              onClick={() => setModal({ type: 'destination', editing: null })}
-              className="text-sm border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-300"
-            >+ Add destination</button>
+            <HeaderMenus
+              hasData={hasData}
+              onAddDestination={() => setModal({ type: 'destination', editing: null })}
+              onAddTransport={() => setModal({ type: 'transport', editing: null })}
+              onAddHotel={() => setModal({ type: 'hotel', editing: null })}
+              onAddActivity={() => setModal({ type: 'activity', editing: null, context: destinations[0] ?? null })}
+              onExport={() => setShowExport(true)}
+              onShare={() => setShowCollab(true)}
+              isCollaborating={collab.isCollaborating}
+              syncStatus={collab.syncStatus}
+            />
             <button
               onClick={() => setDark((d) => !d)}
               className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-400 dark:text-gray-500"

--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -1,0 +1,118 @@
+import { useState, useEffect, useRef } from 'react'
+import { ActivityIcon, BedIcon, TransportIcon } from './Icons'
+
+function DropdownMenu({ label, items, align = 'right' }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false)
+    }
+    function handleKey(e) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 text-sm font-medium"
+        aria-expanded={open}
+      >
+        {label}
+      </button>
+      {open && (
+        <div
+          className={`absolute top-full mt-1.5 w-44 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg z-50 py-1 ${align === 'right' ? 'right-0' : 'left-0'}`}
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              onClick={() => { item.onClick(); setOpen(false) }}
+              disabled={item.disabled}
+              className="w-full text-left px-3 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors flex items-center gap-2.5 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {item.icon && <span className="w-4 flex items-center justify-center">{item.icon}</span>}
+              {item.label}
+              {item.badge}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function HeaderMenus({
+  hasData,
+  onAddDestination,
+  onAddTransport,
+  onAddHotel,
+  onAddActivity,
+  onExport,
+  onShare,
+  isCollaborating,
+  syncStatus,
+}) {
+  const syncColor = { syncing: '#f59e0b', synced: '#22c55e', error: '#ef4444' }[syncStatus] ?? '#9ca3af'
+
+  const addItems = [
+    {
+      label: 'Destination',
+      icon: <span className="text-sky-500 text-base leading-none">+</span>,
+      onClick: onAddDestination,
+    },
+    {
+      label: 'Transport',
+      icon: <TransportIcon type="flight" size={13} color="#9ca3af" />,
+      onClick: onAddTransport,
+    },
+    {
+      label: 'Hotel',
+      icon: <BedIcon size={13} color="#9ca3af" />,
+      onClick: onAddHotel,
+    },
+    {
+      label: 'Activity',
+      icon: <ActivityIcon type="attraction" size={13} color="#9ca3af" />,
+      onClick: onAddActivity,
+    },
+  ]
+
+  const shareItems = [
+    {
+      label: 'Export',
+      icon: <span className="text-gray-400 text-sm leading-none">↑</span>,
+      onClick: onExport,
+      disabled: !hasData,
+    },
+    {
+      label: 'Collaborate',
+      icon: <span className="text-gray-400 text-sm leading-none">⇆</span>,
+      onClick: onShare,
+      badge: isCollaborating ? (
+        <span
+          className="ml-auto w-1.5 h-1.5 rounded-full flex-shrink-0"
+          style={{ background: syncColor }}
+          data-testid="sync-status-dot"
+        />
+      ) : null,
+    },
+  ]
+
+  return (
+    <div className="flex items-center gap-2 flex-shrink-0">
+      <DropdownMenu label="+" items={addItems} align="right" />
+      <DropdownMenu label="↑" items={shareItems} align="right" />
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Light mode: warm tinted background so white cards pop */
+html:not(.dark) body {
+  background-color: #F7F7F5;
+}
+/* Elevate light-mode secondary text for better contrast */
+html:not(.dark) .text-gray-300 {
+  color: #6b7280 !important;
+}
+html:not(.dark) .text-gray-200 {
+  color: #9ca3af !important;
+}
+
 @font-face {
   font-family: 'Geist';
   src: url('../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2') format('woff2');


### PR DESCRIPTION
Replaces the cluttered header button row with two compact dropdown menus:
- [+] for adding destinations, transport, hotels, activities
- [↑] for export and collaborate (with sync status dot)

Also applies warm tinted background (#F7F7F5) in light mode and elevates
gray-200/gray-300 text classes to improve readability.

Closes #9, closes #10

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr