### PR TITLE
Fix blank page on iPad Safari: global UUID polyfill + error boundary

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Polyfill crypto.randomUUID for iOS < 15.4 — runs before any ES module code
+      if (typeof crypto !== 'undefined' && typeof crypto.randomUUID !== 'function') {
+        crypto.randomUUID = function () {
+          return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (Math.random() * 16) | 0;
+            return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+          });
+        };
+      }
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,35 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null }
+  }
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 32, fontFamily: 'system-ui, sans-serif', color: '#111' }}>
+          <h2 style={{ marginBottom: 8 }}>Something went wrong</h2>
+          <pre style={{ background: '#f3f4f6', padding: 16, borderRadius: 8, fontSize: 13, overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {this.state.error.toString()}
+            {'\n'}
+            {this.state.error.stack}
+          </pre>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Problem

Blank page on iPad Safari. ES module `import` statements are hoisted — a polyfill written in `main.jsx` runs *after* all imports are resolved, which means Supabase and other packages could still call `crypto.randomUUID()` before it's patched.

## Fix

- Moves the `crypto.randomUUID` polyfill into `index.html` as an inline `<script>` tag, which runs synchronously **before** any module code
- Adds an `ErrorBoundary` in `main.jsx` that renders the actual error message on screen instead of a blank page — makes future crashes diagnosable on Safari without needing dev tools

## Test plan

- [ ] Open app on iPad Safari — should render instead of blank page
- [ ] If something else is still broken, error boundary shows the exact error text

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr