### PR TITLE
Add ?demo URL seed for testing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import PackingList from './components/PackingList'
 import WeatherWidget from './components/WeatherWidget'
 import MapView from './components/MapView'
 import SummaryDashboard from './components/SummaryDashboard'
+import { createDemoTrip } from './lib/demoData'
 import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
 import HeaderMenus from './components/HeaderMenus'
@@ -111,6 +112,21 @@ export default function App() {
     tripData: { destinations, hotels, activities, transports, packingList, currency: tripCurrency },
     onRemoteUpdate: updateActiveTrip,
   })
+
+  // ── Demo seed (?demo in URL adds a pre-filled trip without touching existing data) ──
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (!params.has('demo')) return
+    window.history.replaceState(null, '', window.location.pathname + window.location.hash)
+    setTrips((prev) => {
+      if (prev.length >= 3) return prev
+      if (prev.some((t) => t.name === 'Europe Demo')) return prev
+      const demo = createDemoTrip()
+      const trip = makeTrip(demo.name, demo)
+      setActiveTripId(trip.id)
+      return [...prev, trip]
+    })
+  }, [])
 
   // ── Trip management ──
   const addTripWithData = useCallback(({ name, destinations, hotels, activities }) => {

--- a/src/lib/demoData.js
+++ b/src/lib/demoData.js
@@ -1,0 +1,48 @@
+import { uuid } from './uuid'
+import { addDays, format } from 'date-fns'
+
+// Creates a realistic demo trip with dates relative to today
+export function createDemoTrip() {
+  const d = (offset) => format(addDays(new Date(), offset), 'yyyy-MM-dd')
+
+  const parisId    = uuid()
+  const romeId     = uuid()
+  const barcelonaId = uuid()
+  const lisbonId   = uuid()
+
+  return {
+    name: 'Europe Demo',
+    destinations: [
+      { id: parisId,     city: 'Paris',     country: 'France',   countryCode: 'FR', arrival: d(14), departure: d(19), type: 'vacation' },
+      { id: romeId,      city: 'Rome',      country: 'Italy',    countryCode: 'IT', arrival: d(19), departure: d(24), type: 'vacation' },
+      { id: barcelonaId, city: 'Barcelona', country: 'Spain',    countryCode: 'ES', arrival: d(24), departure: d(29), type: 'vacation' },
+      { id: lisbonId,    city: 'Lisbon',    country: 'Portugal', countryCode: 'PT', arrival: d(29), departure: d(34), type: 'vacation' },
+    ],
+    hotels: [
+      { id: uuid(), name: 'Hôtel Le Marais',       checkIn: d(14), checkOut: d(19) },
+      { id: uuid(), name: 'Hotel Colosseo',         checkIn: d(19), checkOut: d(24) },
+      { id: uuid(), name: 'Hotel Arts Barcelona',   checkIn: d(24), checkOut: d(29) },
+      { id: uuid(), name: 'Bairro Alto Hotel',      checkIn: d(29), checkOut: d(34) },
+    ],
+    activities: [
+      { id: uuid(), destinationId: parisId,     type: 'attraction', name: 'Eiffel Tower',           date: d(15) },
+      { id: uuid(), destinationId: parisId,     type: 'restaurant', name: 'Dinner at Le Jules Verne', date: d(16) },
+      { id: uuid(), destinationId: parisId,     type: 'shopping',   name: 'Champs-Élysées',          date: d(17) },
+
+      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Colosseum & Roman Forum', date: d(20) },
+      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Vatican Museums',          date: d(21) },
+      { id: uuid(), destinationId: romeId,      type: 'restaurant', name: 'Osteria del Pegno',        date: d(22) },
+
+      { id: uuid(), destinationId: barcelonaId, type: 'attraction', name: 'Sagrada Família',          date: d(25) },
+      { id: uuid(), destinationId: barcelonaId, type: 'shopping',   name: 'La Boqueria Market',       date: d(26) },
+      { id: uuid(), destinationId: barcelonaId, type: 'restaurant', name: 'El Nacional',              date: d(27) },
+
+      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Alfama District Walk',     date: d(30) },
+      { id: uuid(), destinationId: lisbonId,    type: 'restaurant', name: 'Pastéis de Belém',         date: d(31) },
+      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Sintra Day Trip',          date: d(32) },
+    ],
+    transports: [],
+    packingList: [],
+    currency: 'EUR',
+  }
+}


### PR DESCRIPTION
## What

Visiting `/?demo` injects a pre-filled "Europe Demo" trip alongside any existing trips — nothing is overwritten.

**Trip contents:**
- Paris, France — 5 nights — Hôtel Le Marais + Eiffel Tower, Le Jules Verne dinner, Champs-Élysées shopping
- Rome, Italy — 5 nights — Hotel Colosseo + Colosseum, Vatican Museums, Osteria del Pegno
- Barcelona, Spain — 5 nights — Hotel Arts + Sagrada Família, La Boqueria Market, El Nacional
- Lisbon, Portugal — 5 nights — Bairro Alto Hotel + Alfama walk, Pastéis de Belém, Sintra Day Trip

Dates are always relative to today, so the timeline looks current on every visit.

## How to use

Bookmark: `https://delicate-truffle-5ddc98.netlify.app/?demo`

The `?demo` param is stripped from the URL after loading. Visiting again won't duplicate — it skips if "Europe Demo" already exists. Delete the trip from the sidebar to reset.

## Skips when
- Already at 3-trip limit
- "Europe Demo" trip already exists

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr