### PR TITLE
debug: temporary Supabase env var diagnostic log

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -3,6 +3,10 @@ import { createClient } from '@supabase/supabase-js'
 const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+// Temporary diagnostic — remove after confirming env vars are received
+console.log('[supabase] url present:', !!url, '| key present:', !!key)
+if (url) console.log('[supabase] url prefix:', url.slice(0, 30))
+
 // Wrap in try-catch so an iOS compatibility error here doesn't crash the whole app
 let supabase = null
 try {


### PR DESCRIPTION
Temporary diagnostic only — adds two console.log lines to `src/lib/supabase.js` so we can see whether `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are actually reaching the production build.

**After merging + deploy:**
1. Open the live site in Safari
2. Open DevTools → Console
3. Look for lines starting with `[supabase]`
4. Report back what you see — then we'll remove these logs immediately.

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr