### PR TITLE
feat: Google sign-in, cloud trip sync, privacy notice

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,8 +21,11 @@ import { createDemoTrip } from './lib/demoData'
 import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
 import HeaderMenus from './components/HeaderMenus'
+import AuthButton from './components/AuthButton'
 import { shareToWhatsApp, exportTripCard } from './utils/share'
 import { supabase } from './lib/supabase'
+import { useAuth } from './hooks/useAuth'
+import { loadTrips, saveTrip, deleteCloudTrip } from './lib/cloudTrips'
 
 // ── Dark mode ──────────────────────────────────────────────────────────────
 function useDarkMode() {
@@ -82,8 +85,10 @@ function sortByDate(arr, field) {
 // ── App ────────────────────────────────────────────────────────────────────
 export default function App() {
   const [dark, setDark] = useDarkMode()
+  const { user } = useAuth()
   const [trips, setTrips] = useState(() => loadState().trips)
   const [activeTripId, setActiveTripId] = useState(() => { const s = loadState(); return s.activeTripId || s.trips[0]?.id })
+  const localTripsRef = useRef(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const [modal, setModal] = useState(null)
@@ -97,10 +102,33 @@ export default function App() {
   const [transportsOpen, setTransportsOpen] = useState(true)
   const twoColRef = useRef(null)
 
-  // Persist
+  // Persist to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ trips, activeTripId }))
   }, [trips, activeTripId])
+
+  // On sign-in: load cloud trips, or migrate local trips up
+  useEffect(() => {
+    if (!user?.id || !supabase) return
+    if (localTripsRef.current === null) localTripsRef.current = trips
+    loadTrips(user.id).then((cloud) => {
+      if (cloud.length > 0) {
+        setTrips(cloud)
+        setActiveTripId((prev) => cloud.find((t) => t.id === prev)?.id ?? cloud[0].id)
+      } else {
+        localTripsRef.current.forEach((t) => saveTrip(user.id, t).catch(() => {}))
+      }
+    }).catch(() => {})
+  }, [user?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync changes to cloud when signed in (debounced 800ms)
+  useEffect(() => {
+    if (!user?.id || !supabase) return
+    const timer = setTimeout(() => {
+      trips.forEach((t) => saveTrip(user.id, t).catch(() => {}))
+    }, 800)
+    return () => clearTimeout(timer)
+  }, [trips, user?.id])
 
   // ── Active trip helpers ──
   const activeTrip = trips.find((t) => t.id === activeTripId) || trips[0]
@@ -151,14 +179,17 @@ export default function App() {
     setShowQuickStart(false)
   }, [])
 
+  const tripLimit = user ? 5 : 3
+
   const addTrip = (name) => {
-    if (trips.length >= 3) return
+    if (trips.length >= tripLimit) return
     const trip = makeTrip(name)
     setTrips((prev) => [...prev, trip])
     setActiveTripId(trip.id)
     setSidebarOpen(false)
   }
   const deleteTrip = (id) => {
+    if (user?.id && supabase) deleteCloudTrip(id).catch(() => {})
     setTrips((prev) => {
       const next = prev.filter((t) => t.id !== id)
       if (next.length === 0) {
@@ -323,6 +354,7 @@ export default function App() {
         onDelete={deleteTrip}
         onRename={renameTrip}
         dark={dark}
+        tripLimit={tripLimit}
       />
 
       {/* ── Header ── */}
@@ -368,6 +400,7 @@ export default function App() {
             )}
           </div>
           <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
+            <AuthButton user={user} />
             <HeaderMenus
               hasData={hasData}
               onAddDestination={() => setModal({ type: 'destination', editing: null })}

--- a/src/components/AuthButton.jsx
+++ b/src/components/AuthButton.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import { signInWithGoogle, signOut } from '../lib/auth'
+
+function PrivacyNotice({ onAccept, onDismiss }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm" onClick={onDismiss}>
+      <div
+        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">Before you sign in</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">Wayfar — Early Access MVP</p>
+
+        <div className="space-y-3 text-xs text-gray-600 dark:text-gray-400 mb-5">
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Invite-only.</span> This is an early-access MVP shared by invitation. Please do not share the link publicly.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Your data is yours.</span> Only your trip data is stored — nothing else. It is not visible to the app owner, not shared with other users, and never used for any purpose other than showing it back to you.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Infrastructure.</span> This app runs on{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Vercel</span> (hosting) and{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Supabase</span> (authentication &amp; database). Sign-in is handled by{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Google OAuth</span>. No passwords are stored.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">No analytics.</span> There is no tracking, advertising, or analytics of any kind.
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={onDismiss}
+            className="flex-1 text-sm py-2.5 rounded-xl border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onAccept}
+            className="flex-1 text-sm py-2.5 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium hover:opacity-90 transition-opacity"
+          >
+            Continue with Google
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AuthButton({ user }) {
+  const [showNotice, setShowNotice] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const handleSignIn = async () => {
+    setLoading(true)
+    try { await signInWithGoogle() }
+    catch { setLoading(false) }
+  }
+
+  const handleSignOut = async () => {
+    setMenuOpen(false)
+    await signOut()
+  }
+
+  if (user) {
+    const avatar = user.user_metadata?.avatar_url
+    const name = user.user_metadata?.full_name || user.email
+    const initials = name?.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+
+    return (
+      <div className="relative">
+        <button
+          onClick={() => setMenuOpen((o) => !o)}
+          className="w-8 h-8 rounded-full overflow-hidden border border-gray-200 dark:border-gray-700 flex items-center justify-center bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 text-xs font-semibold flex-shrink-0"
+          title={name}
+        >
+          {avatar
+            ? <img src={avatar} alt={name} className="w-full h-full object-cover" referrerPolicy="no-referrer" />
+            : initials}
+        </button>
+        {menuOpen && (
+          <div className="absolute right-0 top-full mt-1.5 w-48 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg z-50 py-1">
+            <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+              <p className="text-xs font-medium text-gray-800 dark:text-gray-200 truncate">{name}</p>
+              <p className="text-xs text-gray-400 truncate">{user.email}</p>
+            </div>
+            <button
+              onClick={handleSignOut}
+              className="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setShowNotice(true)}
+        disabled={loading}
+        className="text-xs px-3 h-8 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 flex-shrink-0"
+      >
+        {loading ? 'Redirecting…' : 'Sign in'}
+      </button>
+      {showNotice && (
+        <PrivacyNotice
+          onAccept={() => { setShowNotice(false); handleSignIn() }}
+          onDismiss={() => setShowNotice(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/TripSidebar.jsx
+++ b/src/components/TripSidebar.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { format } from 'date-fns'
 import { Flag } from './CitySearch'
 
-const MAX_TRIPS = 3
+const DEFAULT_MAX_TRIPS = 3
 
 function TripRow({ trip, isActive, onSelect, onDelete, onRename }) {
   const [editing, setEditing] = useState(false)
@@ -85,11 +85,11 @@ function TripRow({ trip, isActive, onSelect, onDelete, onRename }) {
   )
 }
 
-export default function TripSidebar({ trips, activeTripId, open, onClose, onSelect, onAdd, onNew, onDelete, onRename, dark }) {
+export default function TripSidebar({ trips, activeTripId, open, onClose, onSelect, onAdd, onNew, onDelete, onRename, dark, tripLimit = DEFAULT_MAX_TRIPS }) {
   const [newName, setNewName] = useState('')
   const [adding, setAdding] = useState(false)
   const inputRef = useRef(null)
-  const atLimit = trips.length >= MAX_TRIPS
+  const atLimit = trips.length >= tripLimit
 
   useEffect(() => {
     if (adding) inputRef.current?.focus()

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+export function useAuth() {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!supabase) { setLoading(false); return }
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null)
+      setLoading(false)
+    })
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  return { user, loading }
+}

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,0 +1,13 @@
+import { supabase } from './supabase'
+
+export async function signInWithGoogle() {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo: window.location.origin },
+  })
+  if (error) throw error
+}
+
+export async function signOut() {
+  await supabase.auth.signOut()
+}

--- a/src/lib/cloudTrips.js
+++ b/src/lib/cloudTrips.js
@@ -1,0 +1,24 @@
+import { supabase } from './supabase'
+
+export async function loadTrips(userId) {
+  const { data, error } = await supabase
+    .from('trips')
+    .select('id, name, data')
+    .eq('user_id', userId)
+    .order('data->createdAt')
+  if (error) throw error
+  return data.map(({ id, name, data: d }) => ({ ...d, id, name }))
+}
+
+export async function saveTrip(userId, trip) {
+  const { id, name, ...data } = trip
+  const { error } = await supabase
+    .from('trips')
+    .upsert({ id, user_id: userId, name, data, updated_at: new Date().toISOString() })
+  if (error) throw error
+}
+
+export async function deleteCloudTrip(tripId) {
+  const { error } = await supabase.from('trips').delete().eq('id', tripId)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary

- **Google sign-in** — "Sign in" button in the header triggers Google OAuth via Supabase; after redirect, user's avatar appears with a sign-out menu
- **Privacy notice** — shown before the Google redirect: MVP/invite-only disclaimer, data policy (your data is yours, not visible to owner), and infrastructure disclosure (Vercel, Supabase, Google OAuth)
- **Cloud trip sync** — on sign-in, trips load from Supabase; on any change, synced back automatically (debounced 800ms); on delete, removed from cloud immediately
- **First sign-in migration** — if a user has local trips but no cloud trips yet, they're automatically migrated up to Supabase
- **Trip limits** — 3 trips when anonymous, 5 trips when signed in

## Before merging — run this SQL in Supabase

Go to **Supabase → SQL Editor** and run:

```sql
create table trips (
  id         uuid primary key,
  user_id    uuid references auth.users not null,
  name       text not null,
  data       jsonb not null default '{}',
  updated_at timestamptz default now()
);

alter table trips enable row level security;

create policy "own trips" on trips for all
  using (auth.uid() = user_id)
  with check (auth.uid() = user_id);
```

## Test plan

- [ ] Click "Sign in" → privacy notice appears with MVP disclaimer and infrastructure info
- [ ] Click "Continue with Google" → redirected to Google → back to app → avatar visible
- [ ] Existing trips from localStorage are automatically synced to Supabase on first sign-in
- [ ] Add/edit a destination → change persists after page refresh (coming from Supabase)
- [ ] Sign out → trips still visible from localStorage cache
- [ ] Sign back in → cloud trips reload
- [ ] Trip limit shows 5 when signed in (vs 3 anonymous)

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr