### PR TITLE
feat: welcome splash screen + fix Google auth redirect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
 import HeaderMenus from './components/HeaderMenus'
 import AuthButton from './components/AuthButton'
+import WelcomeScreen from './components/WelcomeScreen'
 import { shareToWhatsApp, exportTripCard } from './utils/share'
 import { supabase } from './lib/supabase'
 import { useAuth } from './hooks/useAuth'
@@ -85,7 +86,9 @@ function sortByDate(arr, field) {
 // ── App ────────────────────────────────────────────────────────────────────
 export default function App() {
   const [dark, setDark] = useDarkMode()
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
+  const [guestMode, setGuestMode] = useState(() => !!localStorage.getItem('wayfar-guest-mode'))
+  const showWelcome = !authLoading && !user && !guestMode
   const [trips, setTrips] = useState(() => loadState().trips)
   const [activeTripId, setActiveTripId] = useState(() => { const s = loadState(); return s.activeTripId || s.trips[0]?.id })
   const localTripsRef = useRef(null)
@@ -686,6 +689,14 @@ export default function App() {
         />
       )}
       <DetailCard item={selectedItem} onClose={() => setSelectedItem(null)} onEdit={handleDetailEdit} />
+      {showWelcome && (
+        <WelcomeScreen
+          onContinueAsGuest={() => {
+            localStorage.setItem('wayfar-guest-mode', 'true')
+            setGuestMode(true)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/AuthButton.jsx
+++ b/src/components/AuthButton.jsx
@@ -1,52 +1,6 @@
 import { useState } from 'react'
 import { signInWithGoogle, signOut } from '../lib/auth'
-
-function PrivacyNotice({ onAccept, onDismiss }) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm" onClick={onDismiss}>
-      <div
-        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm p-6"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">Before you sign in</h2>
-        <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">Wayfar — Early Access MVP</p>
-
-        <div className="space-y-3 text-xs text-gray-600 dark:text-gray-400 mb-5">
-          <p>
-            <span className="font-medium text-gray-800 dark:text-gray-200">Invite-only.</span> This is an early-access MVP shared by invitation. Please do not share the link publicly.
-          </p>
-          <p>
-            <span className="font-medium text-gray-800 dark:text-gray-200">Your data is yours.</span> Only your trip data is stored — nothing else. It is not visible to the app owner, not shared with other users, and never used for any purpose other than showing it back to you.
-          </p>
-          <p>
-            <span className="font-medium text-gray-800 dark:text-gray-200">Infrastructure.</span> This app runs on{' '}
-            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Vercel</span> (hosting) and{' '}
-            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Supabase</span> (authentication &amp; database). Sign-in is handled by{' '}
-            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Google OAuth</span>. No passwords are stored.
-          </p>
-          <p>
-            <span className="font-medium text-gray-800 dark:text-gray-200">No analytics.</span> There is no tracking, advertising, or analytics of any kind.
-          </p>
-        </div>
-
-        <div className="flex gap-2">
-          <button
-            onClick={onDismiss}
-            className="flex-1 text-sm py-2.5 rounded-xl border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={onAccept}
-            className="flex-1 text-sm py-2.5 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium hover:opacity-90 transition-opacity"
-          >
-            Continue with Google
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
+import PrivacyNotice from './PrivacyNotice'
 
 export default function AuthButton({ user }) {
   const [showNotice, setShowNotice] = useState(false)

--- a/src/components/PrivacyNotice.jsx
+++ b/src/components/PrivacyNotice.jsx
@@ -1,0 +1,46 @@
+export default function PrivacyNotice({ onAccept, onDismiss }) {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onDismiss}>
+      <div
+        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">Before you sign in</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">Wayfar — Early Access MVP</p>
+
+        <div className="space-y-3 text-xs text-gray-600 dark:text-gray-400 mb-5">
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Invite-only.</span> This is an early-access MVP shared by invitation. Please do not share the link publicly.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Your data is yours.</span> Only your trip data is stored — nothing else. It is not visible to the app owner, not shared with other users, and never used for any purpose other than showing it back to you.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">Infrastructure.</span> This app runs on{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Vercel</span> (hosting) and{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Supabase</span> (authentication &amp; database). Sign-in is handled by{' '}
+            <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">Google OAuth</span>. No passwords are stored.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800 dark:text-gray-200">No analytics.</span> There is no tracking, advertising, or analytics of any kind.
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={onDismiss}
+            className="flex-1 text-sm py-2.5 rounded-xl border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            Back
+          </button>
+          <button
+            onClick={onAccept}
+            className="flex-1 text-sm py-2.5 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium hover:opacity-90 transition-opacity"
+          >
+            Continue with Google
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import PrivacyNotice from './PrivacyNotice'
+import { signInWithGoogle } from '../lib/auth'
+
+export default function WelcomeScreen({ onContinueAsGuest }) {
+  const [showPrivacy, setShowPrivacy] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const handleSignIn = async () => {
+    setLoading(true)
+    try { await signInWithGoogle() }
+    catch { setLoading(false) }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-md">
+        <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-xs p-8 flex flex-col items-center">
+
+          {/* Logo */}
+          <div className="mb-6 text-center">
+            <h1 className="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">wayfar</h1>
+            <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">Plan your trips, together.</p>
+          </div>
+
+          {/* Actions */}
+          <div className="w-full flex flex-col gap-3">
+            <button
+              onClick={() => setShowPrivacy(true)}
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-2.5 text-sm py-2.5 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {/* Google "G" icon */}
+              <svg width="16" height="16" viewBox="0 0 18 18" fill="none">
+                <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z" fill="#4285F4"/>
+                <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332C2.438 15.983 5.482 18 9 18z" fill="#34A853"/>
+                <path d="M3.964 10.707A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05"/>
+                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0 5.482 0 2.438 2.017.957 4.961L3.964 6.293C4.672 4.166 6.656 3.58 9 3.58z" fill="#EA4335"/>
+              </svg>
+              {loading ? 'Redirecting…' : 'Continue with Google'}
+            </button>
+
+            <button
+              onClick={onContinueAsGuest}
+              className="w-full text-sm py-2.5 rounded-xl border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              Continue without account
+            </button>
+          </div>
+
+          <p className="text-xs text-gray-300 dark:text-gray-600 mt-5 text-center">
+            Early access · Invite only
+          </p>
+        </div>
+      </div>
+
+      {showPrivacy && (
+        <PrivacyNotice
+          onAccept={() => { setShowPrivacy(false); handleSignIn() }}
+          onDismiss={() => setShowPrivacy(false)}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- **Welcome splash screen** — replaces the header "Sign in" button as the primary entry point. Shows on first visit as a centered overlay with two options: "Continue with Google" or "Continue without account". Guest choice is saved to localStorage so it only appears once.
- **PrivacyNotice** extracted into its own component, shared between WelcomeScreen and AuthButton
- **AuthButton** kept in header for already-signed-in users (avatar + sign-out menu) and for guests who want to sign in later

## Fix required before this works (Supabase)

The localhost redirect issue is a Supabase config problem — fix it here:
1. Supabase → **Authentication → URL Configuration**
2. Set **Site URL** to `https://wayfar-eta.vercel.app`
3. Under **Redirect URLs** add `https://wayfar-eta.vercel.app/**`
4. Save

## Test plan

- [ ] Fresh visit (clear localStorage) → welcome screen appears over the app background
- [ ] "Continue without account" → screen dismisses, app usable, doesn't show again on refresh
- [ ] "Continue with Google" → privacy notice appears → "Continue with Google" → redirects to Google → comes back to Vercel URL (not localhost) → avatar visible in header
- [ ] Signed-in user refreshes → no welcome screen, avatar shown directly

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr