### PR TITLE
fix: header Sign in always opens WelcomeScreen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -403,7 +403,10 @@ export default function App() {
             )}
           </div>
           <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
-            <AuthButton user={user} />
+            <AuthButton user={user} onShowWelcome={() => {
+              localStorage.removeItem('wayfar-guest-mode')
+              setGuestMode(false)
+            }} />
             <HeaderMenus
               hasData={hasData}
               onAddDestination={() => setModal({ type: 'destination', editing: null })}

--- a/src/components/AuthButton.jsx
+++ b/src/components/AuthButton.jsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
-import { signInWithGoogle, signOut } from '../lib/auth'
-import PrivacyNotice from './PrivacyNotice'
+import { signOut } from '../lib/auth'
 
-export default function AuthButton({ user }) {
-  const [showNotice, setShowNotice] = useState(false)
+export default function AuthButton({ user, onShowWelcome }) {
   const [menuOpen, setMenuOpen] = useState(false)
-  const [loading, setLoading] = useState(false)
-
-  const handleSignIn = async () => {
-    setLoading(true)
-    try { await signInWithGoogle() }
-    catch { setLoading(false) }
-  }
 
   const handleSignOut = async () => {
     setMenuOpen(false)
@@ -53,20 +44,12 @@ export default function AuthButton({ user }) {
   }
 
   return (
-    <>
-      <button
-        onClick={() => setShowNotice(true)}
-        disabled={loading}
-        className="text-xs px-3 h-8 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 flex-shrink-0"
-      >
-        {loading ? 'Redirecting…' : 'Sign in'}
-      </button>
-      {showNotice && (
-        <PrivacyNotice
-          onAccept={() => { setShowNotice(false); handleSignIn() }}
-          onDismiss={() => setShowNotice(false)}
-        />
-      )}
-    </>
+    <button
+      onClick={onShowWelcome}
+      className="text-xs px-3 h-8 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors flex-shrink-0"
+    >
+      Sign in
+    </button>
   )
 }
+


### PR DESCRIPTION
Clicking "Sign in" from the header (when in guest mode) now re-opens the WelcomeScreen overlay instead of showing the PrivacyNotice directly. The WelcomeScreen is now the single entry point for all sign-in flows.

- `AuthButton` no longer contains any sign-in logic — it calls `onShowWelcome` instead
- `App.jsx` clears `guestMode` when `onShowWelcome` is called, which triggers the WelcomeScreen to appear

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr