### PR TITLE
feat: current weather on destination cards, timeline bars, and detail panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -519,7 +519,7 @@ export default function App() {
                               {destActivities.length > 0 && <><span className="ml-2 text-gray-200 mr-1.5">·</span>{destActivities.length} activit{destActivities.length !== 1 ? 'ies' : 'y'}</>}
                               {dest.budget != null && <span className="ml-2 font-medium" style={{ color: '#166534' }}><span className="text-gray-200 mr-1.5">·</span>${dest.budget.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>}
                             </p>
-                            <WeatherBadge city={dest.city} countryCode={dest.countryCode} date={dest.arrival} />
+                            <WeatherBadge city={dest.city} countryCode={dest.countryCode} departure={dest.departure} />
                           </div>
                           <div className="hidden sm:flex items-center gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                             <button onClick={() => setModal({ type: 'activity', editing: null, context: dest })} className="text-xs text-gray-400 hover:text-gray-600 px-2.5 py-1.5 rounded border border-transparent hover:border-gray-200 transition-colors">+ Activity</button>

--- a/src/components/DetailCard.jsx
+++ b/src/components/DetailCard.jsx
@@ -1,6 +1,7 @@
 import { format, differenceInDays, startOfDay } from 'date-fns'
 import { Flag } from './CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon } from './Icons'
+import { useCurrentWeather, wmoEmoji, isCurrentOrFuture } from '../hooks/useCurrentWeather'
 
 // ── Shared helpers ─────────────────────────────────────────────────────────
 
@@ -46,6 +47,19 @@ function Section({ title, children }) {
 
 // ── Destination card ────────────────────────────────────────────────────────
 
+function WeatherSection({ city, countryCode, departure }) {
+  const weather = useCurrentWeather(city, countryCode, isCurrentOrFuture(departure))
+  if (!weather) return null
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
+      <span>{wmoEmoji(weather.code)}</span>
+      <span>{weather.temp}°</span>
+      <span className="text-gray-400 dark:text-gray-500">·</span>
+      <span className="text-xs text-gray-400 dark:text-gray-500">↑{weather.high}° ↓{weather.low}°</span>
+    </div>
+  )
+}
+
 function DestinationCard({ dest, relatedActivities, relatedHotels }) {
   const nights = differenceInDays(
     startOfDay(new Date(dest.departure)),
@@ -83,6 +97,9 @@ function DestinationCard({ dest, relatedActivities, relatedHotels }) {
         />
         <Row label="Duration" value={`${nights} night${nights !== 1 ? 's' : ''}`} />
       </Section>
+
+      {/* Current weather */}
+      <WeatherSection city={dest.city} countryCode={dest.countryCode} departure={dest.departure} />
 
       {/* Flight info */}
       {hasFlightInfo && (

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -3,6 +3,17 @@ import {
   format, addDays, differenceInDays, startOfDay,
   isSameDay, eachMonthOfInterval,
 } from 'date-fns'
+import { useCurrentWeather, wmoEmoji, isCurrentOrFuture } from '../hooks/useCurrentWeather'
+
+function WeatherChip({ city, countryCode, departure, textColor }) {
+  const weather = useCurrentWeather(city, countryCode, isCurrentOrFuture(departure))
+  if (!weather) return null
+  return (
+    <span style={{ fontSize: 11, color: textColor, opacity: 0.75, whiteSpace: 'nowrap', flexShrink: 0 }}>
+      {wmoEmoji(weather.code)} {weather.temp}° ↑{weather.high}° ↓{weather.low}°
+    </span>
+  )
+}
 import { Flag } from './CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon } from './Icons'
 
@@ -497,6 +508,9 @@ export default function Timeline({
                     <span style={{ fontSize: 11, color: textColor, opacity: 0.6, whiteSpace: 'nowrap', flexShrink: 0 }}>
                       {format(new Date(dest.arrival), 'MMM d')}–{format(new Date(dest.departure), 'MMM d')}
                     </span>
+                  )}
+                  {blockW > 220 && (
+                    <WeatherChip city={dest.city} countryCode={dest.countryCode} departure={dest.departure} textColor={textColor} />
                   )}
 
                   {/* ── Edit / delete buttons on hover ── */}

--- a/src/components/WeatherBadge.jsx
+++ b/src/components/WeatherBadge.jsx
@@ -1,87 +1,12 @@
-import { useState, useEffect } from 'react'
-import { differenceInDays, startOfDay, format } from 'date-fns'
+import { useCurrentWeather, wmoEmoji, isCurrentOrFuture } from '../hooks/useCurrentWeather'
 
-function weatherEmoji(code) {
-  if (code === 0)  return '☀️'
-  if (code <= 3)   return '⛅'
-  if (code <= 48)  return '🌫️'
-  if (code <= 67)  return '🌧️'
-  if (code <= 77)  return '❄️'
-  if (code <= 82)  return '🌦️'
-  return '⛈️'
-}
-
-// Module-level caches survive re-renders and avoid duplicate network calls
-const geoCache = new Map()
-const wxCache = new Map()
-
-async function geocode(city, countryCode) {
-  const key = `${city}|${countryCode}`
-  if (geoCache.has(key)) return geoCache.get(key)
-  const params = new URLSearchParams({ q: `${city}, ${countryCode}`, format: 'json', limit: 1 })
-  const res = await fetch(`https://nominatim.openstreetmap.org/search?${params}`, {
-    headers: { 'Accept-Language': 'en' },
-  })
-  const data = await res.json()
-  const result = data[0] ? { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) } : null
-  geoCache.set(key, result)
-  return result
-}
-
-async function fetchDayWeather(lat, lng, dateStr) {
-  const key = `${lat}|${lng}|${dateStr}`
-  if (wxCache.has(key)) return wxCache.get(key)
-  const params = new URLSearchParams({
-    latitude: lat, longitude: lng,
-    daily: 'temperature_2m_max,temperature_2m_min,weathercode',
-    forecast_days: 14,
-    timezone: 'auto',
-  })
-  const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params}`)
-  const data = await res.json()
-  if (!data.daily) return null
-  const idx = data.daily.time.indexOf(dateStr)
-  if (idx === -1) return null
-  const result = {
-    max: Math.round(data.daily.temperature_2m_max[idx]),
-    min: Math.round(data.daily.temperature_2m_min[idx]),
-    code: data.daily.weathercode[idx],
-  }
-  wxCache.set(key, result)
-  return result
-}
-
-export default function WeatherBadge({ city, countryCode, date }) {
-  const [weather, setWeather] = useState(null)
-
-  useEffect(() => {
-    const arrival = startOfDay(new Date(date))
-    const today = startOfDay(new Date())
-    const daysAway = differenceInDays(arrival, today)
-    // Open-Meteo only provides 14-day forecasts; skip past and far-future dates
-    if (daysAway < 0 || daysAway > 13) return
-
-    const dateStr = format(arrival, 'yyyy-MM-dd')
-    let cancelled = false
-    ;(async () => {
-      try {
-        const coords = await geocode(city, countryCode)
-        if (!coords || cancelled) return
-        const w = await fetchDayWeather(coords.lat, coords.lng, dateStr)
-        if (!cancelled && w) setWeather(w)
-      } catch {
-        // silently fail — weather is decorative
-      }
-    })()
-    return () => { cancelled = true }
-  }, [city, countryCode, date])
-
+export default function WeatherBadge({ city, countryCode, departure }) {
+  const weather = useCurrentWeather(city, countryCode, isCurrentOrFuture(departure))
   if (!weather) return null
 
   return (
-    <span className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500" title="Forecast on arrival day">
-      <span>{weatherEmoji(weather.code)}</span>
-      <span>{weather.max}° / {weather.min}°</span>
+    <span className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 ml-1.5" title="Current weather">
+      {wmoEmoji(weather.code)} {weather.temp}° · ↑{weather.high}° ↓{weather.low}°
     </span>
   )
 }

--- a/src/hooks/useCurrentWeather.js
+++ b/src/hooks/useCurrentWeather.js
@@ -1,0 +1,80 @@
+import { useState, useEffect } from 'react'
+import { startOfDay } from 'date-fns'
+
+// Module-level caches shared across all hook instances
+const geoCache = new Map()
+const wxCache  = new Map() // key → { data, ts }
+const WX_TTL   = 10 * 60 * 1000 // 10 minutes
+
+export function wmoEmoji(code) {
+  if (code === 0)  return '☀️'
+  if (code <= 3)   return '⛅'
+  if (code <= 48)  return '🌫️'
+  if (code <= 67)  return '🌧️'
+  if (code <= 77)  return '❄️'
+  if (code <= 82)  return '🌦️'
+  return '⛈️'
+}
+
+export function isCurrentOrFuture(departure) {
+  return startOfDay(new Date(departure)) >= startOfDay(new Date())
+}
+
+async function geocode(city, countryCode) {
+  const key = `${city}|${countryCode}`
+  if (geoCache.has(key)) return geoCache.get(key)
+  const params = new URLSearchParams({ q: `${city}, ${countryCode}`, format: 'json', limit: 1 })
+  const res = await fetch(`https://nominatim.openstreetmap.org/search?${params}`, {
+    headers: { 'Accept-Language': 'en' },
+  })
+  const data = await res.json()
+  const result = data[0] ? { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) } : null
+  geoCache.set(key, result)
+  return result
+}
+
+async function fetchWeather(lat, lng) {
+  const key = `${lat.toFixed(2)}|${lng.toFixed(2)}`
+  const cached = wxCache.get(key)
+  if (cached && Date.now() - cached.ts < WX_TTL) return cached.data
+
+  const params = new URLSearchParams({
+    latitude: lat, longitude: lng,
+    current_weather: 'true',
+    daily: 'temperature_2m_max,temperature_2m_min',
+    forecast_days: 1,
+    timezone: 'auto',
+  })
+  const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params}`)
+  const json = await res.json()
+  if (!json.current_weather) return null
+
+  const data = {
+    temp: Math.round(json.current_weather.temperature),
+    high: Math.round(json.daily.temperature_2m_max[0]),
+    low:  Math.round(json.daily.temperature_2m_min[0]),
+    code: json.current_weather.weathercode,
+  }
+  wxCache.set(key, { data, ts: Date.now() })
+  return data
+}
+
+export function useCurrentWeather(city, countryCode, enabled = true) {
+  const [weather, setWeather] = useState(null)
+
+  useEffect(() => {
+    if (!enabled || !city || !countryCode) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const coords = await geocode(city, countryCode)
+        if (!coords || cancelled) return
+        const w = await fetchWeather(coords.lat, coords.lng)
+        if (!cancelled && w) setWeather(w)
+      } catch { /* silently fail — weather is decorative */ }
+    })()
+    return () => { cancelled = true }
+  }, [city, countryCode, enabled])
+
+  return weather
+}


### PR DESCRIPTION
## Summary

- Adds real-time current weather (temperature + today's high/low) to three places: destination list cards, timeline bars, and the detail slide-over panel
- Weather only fetches for **current and future** destinations — past ones are skipped
- Uses Open-Meteo (free, no API key) + Nominatim geocoding, with module-level caching (10-min TTL) to avoid redundant calls

## What's new

| Location | What you see |
|---|---|
| Destination list card | `⛅ 24° · ↑28° ↓18°` next to the city meta line |
| Timeline bar | Same badge appears inside the bar when it's wide enough (>220px) |
| Detail panel | Weather row between "Stay" dates and Flight info |

## Test plan

- [ ] Load `/?demo` — destination cards with future dates show weather emoji + temps
- [ ] Past destinations show no weather badge
- [ ] Click a future destination in the timeline → detail panel shows weather row
- [ ] Weather badge appears on wide timeline bars, hidden on narrow ones
- [ ] Network errors / unknown cities fail silently (no visible error)

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr