### PR TITLE
feat: social travel stats panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,18 +22,15 @@ import { createDemoTrip } from './lib/demoData'
 import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
 import HeaderMenus from './components/HeaderMenus'
+import TravelStats from './components/TravelStats'
 import AuthButton from './components/AuthButton'
 import WelcomeScreen from './components/WelcomeScreen'
 import { shareToWhatsApp, exportTripCard, copyTripShareLink, deserializeTripFromUrl } from './utils/share'
 import { openTripSummaryPrint } from './utils/export'
 import { supabase } from './lib/supabase'
 import { useAuth } from './hooks/useAuth'
-import { loadTrips, saveTrip, deleteCloudTrip } from './lib/cloudTrips'
-import {
-  STORAGE_KEY, DARK_MODE_KEY, GUEST_MODE_KEY,
-  TRIP_LIMIT_GUEST, TRIP_LIMIT_AUTH,
-  CLOUD_SYNC_DEBOUNCE_MS,
-} from './lib/constants'
+import { useCloudSync } from './hooks/useCloudSync'
+import { STORAGE_KEY, DARK_MODE_KEY, GUEST_MODE_KEY, TRIP_LIMIT_GUEST, TRIP_LIMIT_AUTH } from './lib/constants'
 
 // ── Dark mode ──────────────────────────────────────────────────────────────
 function useDarkMode() {
@@ -98,13 +95,13 @@ export default function App() {
   const showWelcome = !authLoading && !user && !guestMode
   const [trips, setTrips] = useState(() => loadState().trips)
   const [activeTripId, setActiveTripId] = useState(() => { const s = loadState(); return s.activeTripId || s.trips[0]?.id })
-  const localTripsRef = useRef(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const [modal, setModal] = useState(null)
   const [showExport, setShowExport] = useState(false)
   const [showQuickStart, setShowQuickStart] = useState(false)
   const [showCollab, setShowCollab] = useState(false)
+  const [showStats, setShowStats] = useState(false)
   const [selectedItem, setSelectedItem] = useState(null)
   const [destSplit, setDestSplit] = useState(63)
   const [destsOpen, setDestsOpen] = useState(true)
@@ -117,28 +114,7 @@ export default function App() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ trips, activeTripId }))
   }, [trips, activeTripId])
 
-  // On sign-in: load cloud trips, or migrate local trips up
-  useEffect(() => {
-    if (!user?.id || !supabase) return
-    if (localTripsRef.current === null) localTripsRef.current = trips
-    loadTrips(user.id).then((cloud) => {
-      if (cloud.length > 0) {
-        setTrips(cloud)
-        setActiveTripId((prev) => cloud.find((t) => t.id === prev)?.id ?? cloud[0].id)
-      } else {
-        localTripsRef.current.forEach((t) => saveTrip(user.id, t).catch((err) => console.error('[Wayfar] cloud migration failed', err)))
-      }
-    }).catch((err) => console.error('[Wayfar] loadTrips failed', err))
-  }, [user?.id]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Sync changes to cloud when signed in
-  useEffect(() => {
-    if (!user?.id || !supabase) return
-    const timer = setTimeout(() => {
-      trips.forEach((t) => saveTrip(user.id, t).catch((err) => console.error('[Wayfar] saveTrip failed', err)))
-    }, CLOUD_SYNC_DEBOUNCE_MS)
-    return () => clearTimeout(timer)
-  }, [trips, user?.id])
+  const { deleteFromCloud } = useCloudSync({ userId: user?.id, trips, setTrips, setActiveTripId })
 
   // ── Active trip helpers ──
   const activeTrip = trips.find((t) => t.id === activeTripId) || trips[0]
@@ -199,7 +175,7 @@ export default function App() {
     setSidebarOpen(false)
   }
   const deleteTrip = (id) => {
-    if (user?.id && supabase) deleteCloudTrip(id).catch((err) => console.error('[Wayfar] deleteCloudTrip failed', err))
+    deleteFromCloud(id)
     setTrips((prev) => {
       const next = prev.filter((t) => t.id !== id)
       if (next.length === 0) {
@@ -487,6 +463,7 @@ export default function App() {
               onWhatsApp={() => shareToWhatsApp(destinations, collab.isCollaborating ? collab.tripCode : undefined)}
               onInstagram={() => exportTripCard(destinations, activeTrip?.name)}
               onShare={() => setShowCollab(true)}
+              onTravelStats={() => setShowStats(true)}
               isCollaborating={collab.isCollaborating}
               syncStatus={collab.syncStatus}
             />
@@ -769,6 +746,14 @@ export default function App() {
           onStopSharing={collab.stopSharing}
           onClose={() => setShowCollab(false)}
           supabaseReady={supabase !== null}
+        />
+      )}
+      {showStats && (
+        <TravelStats
+          trips={trips}
+          user={user}
+          dark={dark}
+          onClose={() => setShowStats(false)}
         />
       )}
       <DetailCard item={selectedItem} onClose={() => setSelectedItem(null)} onEdit={handleDetailEdit} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ import WeatherWidget from './components/WeatherWidget'
 import WeatherBadge from './components/WeatherBadge'
 import MapView from './components/MapView'
 import SummaryDashboard from './components/SummaryDashboard'
-import { createDemoTrip } from './lib/demoData'
+import { createDemoTrips } from './lib/demoData'
 import { Flag } from './components/CitySearch'
 import { ACTIVITY_CONFIG, ActivityIcon, BedIcon, TRANSPORT_CONFIG, TransportIcon, PlaneIcon, SuitcaseIcon } from './components/Icons'
 import HeaderMenus from './components/HeaderMenus'
@@ -139,12 +139,14 @@ export default function App() {
     if (!params.has('demo')) return
     window.history.replaceState(null, '', window.location.pathname + window.location.hash)
     setTrips((prev) => {
-      if (prev.length >= 3) return prev
       if (prev.some((t) => t.name === 'Europe Demo')) return prev
-      const demo = createDemoTrip()
-      const trip = makeTrip(demo.name, demo)
-      setActiveTripId(trip.id)
-      return [...prev, trip]
+      const [europeData, asiaData] = createDemoTrips()
+      const europeTrip = makeTrip(europeData.name, europeData)
+      const asiaTrip   = makeTrip(asiaData.name, asiaData)
+      setActiveTripId(europeTrip.id)
+      // Drop any empty default "My Trip" placeholder so the sidebar stays clean
+      const existing = prev.filter((t) => !(t.name === 'My Trip' && t.destinations.length === 0))
+      return [...existing, asiaTrip, europeTrip]
     })
   }, [])
 

--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -68,6 +68,7 @@ export default function HeaderMenus({
   onWhatsApp,
   onInstagram,
   onShare,
+  onTravelStats,
   isCollaborating,
   syncStatus,
 }) {
@@ -147,6 +148,15 @@ export default function HeaderMenus({
     <div className="flex items-center gap-2 flex-shrink-0">
       <DropdownMenu label="+" items={addItems} align="right" />
       <DropdownMenu label="↑" items={shareItems} align="right" />
+      {hasData && (
+        <button
+          onClick={onTravelStats}
+          title="Travel Stats"
+          className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 text-sm"
+        >
+          📊
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/TravelStats.jsx
+++ b/src/components/TravelStats.jsx
@@ -1,0 +1,379 @@
+import { useState, useMemo, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+import { Flag } from './CitySearch'
+import {
+  yearDistanceKm,
+  yearGeographicStats,
+  yearNightsAway,
+  getAvailableYears,
+  getFunComparisons,
+  getAchievementBadges,
+  getTravelPersonality,
+  multiYearKm,
+  topCities,
+  topCountries,
+} from '../utils/travelStats'
+import { publishStats, getPercentile } from '../lib/communityStats'
+
+const TIER_COLORS = {
+  bronze: { bg: '#fef3c7', text: '#92400e', ring: '#f59e0b' },
+  silver: { bg: '#f1f5f9', text: '#475569', ring: '#94a3b8' },
+  gold:   { bg: '#fefce8', text: '#713f12', ring: '#eab308' },
+}
+
+function StatCard({ value, label, sub }) {
+  return (
+    <div className="rounded-xl border border-gray-100 dark:border-gray-800 bg-white/90 dark:bg-gray-900/90 p-4 flex flex-col gap-1">
+      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 leading-none">{value}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
+      {sub && <p className="text-xs text-gray-400 dark:text-gray-500">{sub}</p>}
+    </div>
+  )
+}
+
+function SparklineChart({ data, dark }) {
+  if (data.length < 2) return null
+  const max = Math.max(...data.map((d) => d.km), 1)
+  const W = 100, H = 28
+  const pts = data.map((d, i) => {
+    const x = (i / (data.length - 1)) * W
+    const y = H - (d.km / max) * H
+    return `${x},${y}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ height: 28 }}>
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke={dark ? '#60a5fa' : '#3b82f6'}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {data.map((d, i) => {
+        const x = (i / (data.length - 1)) * W
+        const y = H - (d.km / max) * H
+        return <circle key={d.year} cx={x} cy={y} r={2} fill={dark ? '#60a5fa' : '#3b82f6'} />
+      })}
+    </svg>
+  )
+}
+
+export default function TravelStats({ trips, user, dark, onClose }) {
+  const currentYear = new Date().getFullYear()
+  const availableYears = useMemo(() => getAvailableYears(trips), [trips])
+  const [selectedYear, setSelectedYear] = useState(() => availableYears[0] ?? currentYear)
+  const [compIdx, setCompIdx] = useState(0)
+  const [percentileData, setPercentileData] = useState(null)
+  const [loadingPercentile, setLoadingPercentile] = useState(false)
+  const [published, setPublished] = useState(false)
+  const [publishing, setPublishing] = useState(false)
+  const [showAllComparisons, setShowAllComparisons] = useState(false)
+  const [showTopCities, setShowTopCities] = useState(false)
+
+  const distResult = useMemo(() => yearDistanceKm(trips, selectedYear), [trips, selectedYear])
+  const geo = useMemo(() => yearGeographicStats(trips, selectedYear), [trips, selectedYear])
+  const nights = useMemo(() => yearNightsAway(trips, selectedYear), [trips, selectedYear])
+  const comparisons = useMemo(() => getFunComparisons(distResult.km), [distResult.km])
+  const badges = useMemo(() => getAchievementBadges({
+    km: distResult.km,
+    nightsAway: nights.total,
+    countryCodes: geo.countryCodes,
+    continents: geo.continents,
+    destinationCount: geo.destinationCount,
+  }), [distResult.km, nights.total, geo])
+  const personality = useMemo(() => getTravelPersonality(geo, distResult), [geo, distResult])
+
+  const sparkYears = useMemo(() => {
+    const last4 = [...new Set([...availableYears, currentYear])].sort((a, b) => a - b).slice(-4)
+    return multiYearKm(trips, last4)
+  }, [trips, availableYears, currentYear])
+
+  const cities = useMemo(() => topCities(trips, 3), [trips])
+  const countries = useMemo(() => topCountries(trips, 3), [trips])
+
+  const featuredComparison = comparisons[compIdx] ?? null
+
+  useEffect(() => {
+    if (!user || !supabase || distResult.km === 0) return
+    setLoadingPercentile(true)
+    getPercentile(distResult.km, selectedYear)
+      .then(setPercentileData)
+      .catch(() => setPercentileData(null))
+      .finally(() => setLoadingPercentile(false))
+  }, [user, distResult.km, selectedYear])
+
+  async function handlePublish() {
+    if (!user || publishing) return
+    setPublishing(true)
+    try {
+      await publishStats(user.id, selectedYear, {
+        km: distResult.km,
+        nightsAway: nights.total,
+        countryCodes: geo.countryCodes,
+        continents: geo.continents,
+        destinationCount: geo.destinationCount,
+      })
+      setPublished(true)
+      const updated = await getPercentile(distResult.km, selectedYear)
+      setPercentileData(updated)
+    } catch {
+      // silent — community publish is optional
+    } finally {
+      setPublishing(false)
+    }
+  }
+
+  const kmFormatted = Math.round(distResult.km).toLocaleString('en-US')
+  const prevYear = sparkYears.find((d) => d.year === selectedYear - 1)
+  const yoy = prevYear && prevYear.km > 0
+    ? Math.round(((distResult.km - prevYear.km) / prevYear.km) * 100)
+    : null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-end">
+      <div className="absolute inset-0 bg-black/20 dark:bg-black/40" onClick={onClose} />
+      <div className="relative h-full w-full max-w-md bg-white dark:bg-gray-950 shadow-2xl overflow-y-auto flex flex-col">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800 sticky top-0 bg-white dark:bg-gray-950 z-10">
+          <div className="flex items-center gap-3">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Travel Stats</h2>
+            <div className="flex gap-1">
+              {availableYears.slice(0, 5).map((y) => (
+                <button
+                  key={y}
+                  onClick={() => { setSelectedYear(y); setCompIdx(0); setPercentileData(null); setPublished(false) }}
+                  className={`px-2 py-0.5 rounded-md text-xs font-medium transition-colors ${
+                    y === selectedYear
+                      ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900'
+                      : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  {y}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 px-5 py-5 space-y-6">
+
+          {/* Personality badge */}
+          {personality && (
+            <div className="flex items-center gap-2 bg-gray-50 dark:bg-gray-900 rounded-xl px-4 py-3 border border-gray-100 dark:border-gray-800">
+              <span className="text-xl">{personality.emoji}</span>
+              <div>
+                <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{personality.label}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{personality.description}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Big stat cards */}
+          {geo.destinationCount === 0 ? (
+            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-8">No trips in {selectedYear} yet.</p>
+          ) : (
+            <>
+              <div className="grid grid-cols-3 gap-3">
+                <StatCard
+                  value={`${kmFormatted} km`}
+                  label="traveled"
+                  sub={yoy != null ? `${yoy >= 0 ? '+' : ''}${yoy}% vs ${selectedYear - 1}` : null}
+                />
+                <StatCard
+                  value={nights.total}
+                  label="nights away"
+                  sub={nights.vacation > 0 && nights.business > 0
+                    ? `${nights.vacation} vacation · ${nights.business} business`
+                    : null}
+                />
+                <StatCard
+                  value={geo.countryCodes.length}
+                  label={`countr${geo.countryCodes.length !== 1 ? 'ies' : 'y'}`}
+                  sub={geo.continents.length > 0 ? `${geo.continents.length} continent${geo.continents.length !== 1 ? 's' : ''}` : null}
+                />
+              </div>
+
+              {/* Secondary stats */}
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {geo.tripCount} trip{geo.tripCount !== 1 ? 's' : ''} · {geo.destinationCount} destination{geo.destinationCount !== 1 ? 's' : ''}
+                {distResult.approximateCount > 0 && (
+                  <span className="ml-2 text-amber-500">· {distResult.approximateCount} leg{distResult.approximateCount !== 1 ? 's' : ''} approximate</span>
+                )}
+              </p>
+
+              {/* Sparkline */}
+              {sparkYears.length > 1 && (
+                <div>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Year-over-year distance</p>
+                  <SparklineChart data={sparkYears} dark={dark} />
+                  <div className="flex justify-between mt-1">
+                    {sparkYears.map((d) => (
+                      <span key={d.year} className={`text-xs ${d.year === selectedYear ? 'text-blue-500 font-medium' : 'text-gray-400 dark:text-gray-600'}`}>
+                        {d.year}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Fun comparison */}
+              {featuredComparison && (
+                <div className="rounded-xl border border-gray-100 dark:border-gray-800 bg-white/90 dark:bg-gray-900/90 p-4">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wider font-medium">Distance comparison</p>
+                  <div className="flex items-start gap-3">
+                    <span className="text-2xl">{featuredComparison.emoji}</span>
+                    <p className="text-sm text-gray-800 dark:text-gray-200 leading-relaxed flex-1">{featuredComparison.text}</p>
+                  </div>
+                  {/* Progress bar */}
+                  <div className="mt-3 w-full h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-blue-400 dark:bg-blue-500 transition-all duration-500"
+                      style={{ width: `${Math.min(100, featuredComparison.ratio >= 1 ? 100 : featuredComparison.ratio * 100)}%` }}
+                    />
+                  </div>
+                  <div className="flex justify-between mt-2">
+                    <button
+                      onClick={() => setCompIdx((i) => (i - 1 + comparisons.length) % comparisons.length)}
+                      className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    >
+                      ◄
+                    </button>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">{compIdx + 1} / {comparisons.length}</span>
+                    <button
+                      onClick={() => setCompIdx((i) => (i + 1) % comparisons.length)}
+                      className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    >
+                      ►
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Achievement badges */}
+              {badges.some((b) => b.earned) && (
+                <div>
+                  <p className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider mb-3">Achievements</p>
+                  <div className="grid grid-cols-3 gap-2">
+                    {badges.map((badge) => {
+                      const tier = TIER_COLORS[badge.tier]
+                      return (
+                        <div
+                          key={badge.id}
+                          title={badge.description}
+                          className={`rounded-xl p-3 flex flex-col items-center gap-1.5 border transition-opacity ${
+                            badge.earned ? 'opacity-100' : 'opacity-25'
+                          }`}
+                          style={badge.earned
+                            ? { background: tier.bg, borderColor: tier.ring, color: tier.text }
+                            : { background: '#f9fafb', borderColor: '#e5e7eb' }
+                          }
+                        >
+                          <span className="text-xl">{badge.emoji}</span>
+                          <span className="text-xs font-medium text-center leading-tight">{badge.label}</span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Community percentile */}
+              <div className="rounded-xl border border-gray-100 dark:border-gray-800 bg-white/90 dark:bg-gray-900/90 p-4">
+                <p className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider mb-3">Community</p>
+                {!user ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Sign in to compare yourself with the Wayfar community.</p>
+                ) : !supabase ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Community stats require a Supabase connection.</p>
+                ) : loadingPercentile ? (
+                  <p className="text-sm text-gray-400 dark:text-gray-500">Loading…</p>
+                ) : percentileData ? (
+                  <div className="space-y-3">
+                    <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                      You're in the top{' '}
+                      <span className="text-blue-600 dark:text-blue-400 font-semibold">
+                        {100 - percentileData.percentile}%
+                      </span>{' '}
+                      of Wayfar travelers for {selectedYear}
+                    </p>
+                    <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-blue-400 dark:bg-blue-500"
+                        style={{ width: `${percentileData.percentile}%` }}
+                      />
+                    </div>
+                    <div className="flex justify-between text-xs text-gray-400 dark:text-gray-500">
+                      <span>{Math.round(distResult.km).toLocaleString('en-US')} km you</span>
+                      <span>avg {percentileData.avgKm.toLocaleString('en-US')} km</span>
+                    </div>
+                    <p className="text-xs text-gray-400 dark:text-gray-500">Based on {percentileData.sampleSize.toLocaleString('en-US')} travelers</p>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Share your anonymised stats to see how you rank against the community.</p>
+                    <button
+                      onClick={handlePublish}
+                      disabled={publishing || published}
+                      className="px-3 py-1.5 text-xs font-medium rounded-lg bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors disabled:opacity-50"
+                    >
+                      {publishing ? 'Publishing…' : published ? 'Stats shared ✓' : 'Publish my stats'}
+                    </button>
+                    <p className="text-xs text-gray-400 dark:text-gray-500">No personal data is shared — only your total km, nights, and country count.</p>
+                  </div>
+                )}
+              </div>
+
+              {/* Countries visited */}
+              {geo.countryCodes.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider mb-2">Countries in {selectedYear}</p>
+                  <div className="flex flex-wrap gap-2">
+                    {geo.countryCodes.map((cc, i) => (
+                      <div key={cc} className="flex items-center gap-1.5">
+                        <Flag code={cc} country={geo.countries[i]} />
+                        <span className="text-xs text-gray-600 dark:text-gray-400">{geo.countries[i]}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Top cities / countries (all-time) */}
+              {cities.length > 0 && (
+                <div>
+                  <button
+                    onClick={() => setShowTopCities((v) => !v)}
+                    className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider mb-2 flex items-center gap-1 hover:text-gray-800 dark:hover:text-gray-200"
+                  >
+                    All-time favourites <span>{showTopCities ? '▲' : '▼'}</span>
+                  </button>
+                  {showTopCities && (
+                    <div className="space-y-1">
+                      {cities.map((c) => (
+                        <div key={`${c.city}|${c.countryCode}`} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                          <Flag code={c.countryCode} country={c.country} />
+                          <span className="font-medium">{c.city}</span>
+                          <span className="text-gray-400 dark:text-gray-500">·</span>
+                          <span>{c.visits} trip{c.visits !== 1 ? 's' : ''}</span>
+                          <span className="text-gray-400 dark:text-gray-500">·</span>
+                          <span>{c.nights} night{c.nights !== 1 ? 's' : ''}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -1,0 +1,45 @@
+import { useRef, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+import { loadTrips, saveTrip, deleteCloudTrip } from '../lib/cloudTrips'
+import { CLOUD_SYNC_DEBOUNCE_MS } from '../lib/constants'
+
+export function useCloudSync({ userId, trips, setTrips, setActiveTripId }) {
+  // Snapshot of local trips taken at the moment a user first signs in,
+  // used to migrate them to the cloud if the cloud is empty.
+  const localSnapshotRef = useRef(null)
+
+  useEffect(() => {
+    if (!userId || !supabase) return
+    if (localSnapshotRef.current === null) localSnapshotRef.current = trips
+
+    loadTrips(userId)
+      .then((cloudTrips) => {
+        if (cloudTrips.length > 0) {
+          setTrips(cloudTrips)
+          setActiveTripId((prev) => cloudTrips.find((t) => t.id === prev)?.id ?? cloudTrips[0].id)
+        } else {
+          localSnapshotRef.current.forEach((t) =>
+            saveTrip(userId, t).catch((err) => console.error('[Wayfar] cloud migration failed', err))
+          )
+        }
+      })
+      .catch((err) => console.error('[Wayfar] loadTrips failed', err))
+  }, [userId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!userId || !supabase) return
+    const timer = setTimeout(() => {
+      trips.forEach((t) =>
+        saveTrip(userId, t).catch((err) => console.error('[Wayfar] saveTrip failed', err))
+      )
+    }, CLOUD_SYNC_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [trips, userId])
+
+  const deleteFromCloud = (tripId) => {
+    if (!userId || !supabase) return
+    deleteCloudTrip(tripId).catch((err) => console.error('[Wayfar] deleteCloudTrip failed', err))
+  }
+
+  return { deleteFromCloud }
+}

--- a/src/lib/communityStats.js
+++ b/src/lib/communityStats.js
@@ -1,0 +1,44 @@
+import { supabase } from './supabase'
+
+export async function publishStats(userId, year, stats) {
+  if (!supabase) return
+  const { error } = await supabase.from('community_stats').upsert(
+    {
+      user_id:         userId,
+      year,
+      km_traveled:     Math.round(stats.km),
+      nights_away:     stats.nightsAway,
+      country_count:   stats.countryCodes.length,
+      continent_count: stats.continents.length,
+      dest_count:      stats.destinationCount,
+      published_at:    new Date().toISOString(),
+    },
+    { onConflict: 'user_id,year' }
+  )
+  if (error) throw error
+}
+
+export async function getPercentile(km, year) {
+  if (!supabase) return null
+  const { data, error } = await supabase.rpc('get_travel_percentile', {
+    p_km: Math.round(km),
+    p_year: year,
+  })
+  if (error || !data) return null
+  const { percentile, avg_km, median_km, sample_size, p75_km, p90_km } = data
+  if (!sample_size || sample_size < 10) return null
+  return {
+    percentile: Math.round(percentile ?? 0),
+    avgKm: Math.round(avg_km ?? 0),
+    medianKm: Math.round(median_km ?? 0),
+    sampleSize: sample_size,
+    p75Km: Math.round(p75_km ?? 0),
+    p90Km: Math.round(p90_km ?? 0),
+  }
+}
+
+export async function getCommunityInsights(year) {
+  const result = await getPercentile(0, year)
+  if (!result) return null
+  return { totalUsers: result.sampleSize, medianKm: result.medianKm, p75Km: result.p75Km, p90Km: result.p90Km }
+}

--- a/src/lib/demoData.js
+++ b/src/lib/demoData.js
@@ -1,22 +1,26 @@
 import { uuid } from './uuid'
 import { addDays, format } from 'date-fns'
 
-// Creates a realistic demo trip with dates relative to today
-export function createDemoTrip() {
+export function createDemoTrips() {
   const d = (offset) => format(addDays(new Date(), offset), 'yyyy-MM-dd')
 
-  const parisId    = uuid()
-  const romeId     = uuid()
+  const parisId     = uuid()
+  const romeId      = uuid()
   const barcelonaId = uuid()
-  const lisbonId   = uuid()
+  const lisbonId    = uuid()
 
-  return {
+  const tokyoId   = uuid()
+  const seoulId   = uuid()
+  const bangkokId = uuid()
+  const baliId    = uuid()
+
+  const europeTrip = {
     name: 'Europe Demo',
     destinations: [
-      { id: parisId,     city: 'Paris',     country: 'France',   countryCode: 'FR', arrival: d(14), departure: d(19), type: 'vacation' },
-      { id: romeId,      city: 'Rome',      country: 'Italy',    countryCode: 'IT', arrival: d(19), departure: d(24), type: 'vacation' },
-      { id: barcelonaId, city: 'Barcelona', country: 'Spain',    countryCode: 'ES', arrival: d(24), departure: d(29), type: 'vacation' },
-      { id: lisbonId,    city: 'Lisbon',    country: 'Portugal', countryCode: 'PT', arrival: d(29), departure: d(34), type: 'vacation' },
+      { id: parisId,     city: 'Paris',     country: 'France',      countryCode: 'FR', lat: 48.8566,  lng:   2.3522, arrival: d(14), departure: d(19), type: 'vacation' },
+      { id: romeId,      city: 'Rome',      country: 'Italy',       countryCode: 'IT', lat: 41.9028,  lng:  12.4964, arrival: d(19), departure: d(24), type: 'vacation' },
+      { id: barcelonaId, city: 'Barcelona', country: 'Spain',       countryCode: 'ES', lat: 41.3851,  lng:   2.1734, arrival: d(24), departure: d(29), type: 'vacation' },
+      { id: lisbonId,    city: 'Lisbon',    country: 'Portugal',    countryCode: 'PT', lat: 38.7169,  lng:  -9.1395, arrival: d(29), departure: d(34), type: 'vacation' },
     ],
     hotels: [
       { id: uuid(), name: 'Hôtel Le Marais',       checkIn: d(14), checkOut: d(19) },
@@ -25,24 +29,59 @@ export function createDemoTrip() {
       { id: uuid(), name: 'Bairro Alto Hotel',      checkIn: d(29), checkOut: d(34) },
     ],
     activities: [
-      { id: uuid(), destinationId: parisId,     type: 'attraction', name: 'Eiffel Tower',           date: d(15) },
-      { id: uuid(), destinationId: parisId,     type: 'restaurant', name: 'Dinner at Le Jules Verne', date: d(16) },
-      { id: uuid(), destinationId: parisId,     type: 'shopping',   name: 'Champs-Élysées',          date: d(17) },
-
-      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Colosseum & Roman Forum', date: d(20) },
-      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Vatican Museums',          date: d(21) },
-      { id: uuid(), destinationId: romeId,      type: 'restaurant', name: 'Osteria del Pegno',        date: d(22) },
-
-      { id: uuid(), destinationId: barcelonaId, type: 'attraction', name: 'Sagrada Família',          date: d(25) },
-      { id: uuid(), destinationId: barcelonaId, type: 'shopping',   name: 'La Boqueria Market',       date: d(26) },
-      { id: uuid(), destinationId: barcelonaId, type: 'restaurant', name: 'El Nacional',              date: d(27) },
-
-      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Alfama District Walk',     date: d(30) },
-      { id: uuid(), destinationId: lisbonId,    type: 'restaurant', name: 'Pastéis de Belém',         date: d(31) },
-      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Sintra Day Trip',          date: d(32) },
+      { id: uuid(), destinationId: parisId,     type: 'attraction', name: 'Eiffel Tower',             date: d(15) },
+      { id: uuid(), destinationId: parisId,     type: 'restaurant', name: 'Dinner at Le Jules Verne',  date: d(16) },
+      { id: uuid(), destinationId: parisId,     type: 'shopping',   name: 'Champs-Élysées',            date: d(17) },
+      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Colosseum & Roman Forum',   date: d(20) },
+      { id: uuid(), destinationId: romeId,      type: 'attraction', name: 'Vatican Museums',            date: d(21) },
+      { id: uuid(), destinationId: romeId,      type: 'restaurant', name: 'Osteria del Pegno',          date: d(22) },
+      { id: uuid(), destinationId: barcelonaId, type: 'attraction', name: 'Sagrada Família',            date: d(25) },
+      { id: uuid(), destinationId: barcelonaId, type: 'shopping',   name: 'La Boqueria Market',         date: d(26) },
+      { id: uuid(), destinationId: barcelonaId, type: 'restaurant', name: 'El Nacional',                date: d(27) },
+      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Alfama District Walk',       date: d(30) },
+      { id: uuid(), destinationId: lisbonId,    type: 'restaurant', name: 'Pastéis de Belém',           date: d(31) },
+      { id: uuid(), destinationId: lisbonId,    type: 'attraction', name: 'Sintra Day Trip',            date: d(32) },
     ],
     transports: [],
     packingList: [],
     currency: 'EUR',
   }
+
+  // Past-year Asia trip — gives the Travel Stats sparkline and year-over-year data
+  const asiaTrip = {
+    name: 'Asia 2025',
+    destinations: [
+      { id: tokyoId,   city: 'Tokyo',   country: 'Japan',        countryCode: 'JP', lat:  35.6762, lng: 139.6503, arrival: '2025-03-20', departure: '2025-03-26', type: 'vacation' },
+      { id: seoulId,   city: 'Seoul',   country: 'South Korea',  countryCode: 'KR', lat:  37.5665, lng: 126.9780, arrival: '2025-03-26', departure: '2025-03-31', type: 'vacation' },
+      { id: bangkokId, city: 'Bangkok', country: 'Thailand',     countryCode: 'TH', lat:  13.7563, lng: 100.5018, arrival: '2025-04-01', departure: '2025-04-07', type: 'vacation' },
+      { id: baliId,    city: 'Bali',    country: 'Indonesia',    countryCode: 'ID', lat:  -8.3405, lng: 115.0920, arrival: '2025-04-07', departure: '2025-04-14', type: 'vacation' },
+    ],
+    hotels: [
+      { id: uuid(), name: 'Park Hyatt Tokyo',          checkIn: '2025-03-20', checkOut: '2025-03-26' },
+      { id: uuid(), name: 'Lotte Hotel Seoul',          checkIn: '2025-03-26', checkOut: '2025-03-31' },
+      { id: uuid(), name: 'Mandarin Oriental Bangkok',  checkIn: '2025-04-01', checkOut: '2025-04-07' },
+      { id: uuid(), name: 'COMO Uma Canggu',            checkIn: '2025-04-07', checkOut: '2025-04-14' },
+    ],
+    activities: [
+      { id: uuid(), destinationId: tokyoId,   type: 'attraction', name: 'Shinjuku Gyoen Cherry Blossoms', date: '2025-03-21' },
+      { id: uuid(), destinationId: tokyoId,   type: 'restaurant', name: 'Sukiyabashi Jiro',                date: '2025-03-22' },
+      { id: uuid(), destinationId: tokyoId,   type: 'shopping',   name: 'Akihabara Electronics District',  date: '2025-03-24' },
+      { id: uuid(), destinationId: seoulId,   type: 'attraction', name: 'Gyeongbokgung Palace',            date: '2025-03-27' },
+      { id: uuid(), destinationId: seoulId,   type: 'restaurant', name: 'Gwangjang Market Street Food',    date: '2025-03-28' },
+      { id: uuid(), destinationId: bangkokId, type: 'attraction', name: 'Wat Phra Kaew & Grand Palace',    date: '2025-04-02' },
+      { id: uuid(), destinationId: bangkokId, type: 'restaurant', name: 'Nahm Restaurant',                 date: '2025-04-04' },
+      { id: uuid(), destinationId: baliId,    type: 'attraction', name: 'Tegalalang Rice Terraces',        date: '2025-04-08' },
+      { id: uuid(), destinationId: baliId,    type: 'restaurant', name: 'Locavore Restaurant',             date: '2025-04-10' },
+    ],
+    transports: [],
+    packingList: [],
+    currency: 'USD',
+  }
+
+  return [europeTrip, asiaTrip]
+}
+
+// Single-trip export kept for any existing callers
+export function createDemoTrip() {
+  return createDemoTrips()[0]
 }

--- a/src/utils/__tests__/travelStats.test.js
+++ b/src/utils/__tests__/travelStats.test.js
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest'
+import {
+  haversineKm,
+  resolveCoords,
+  tripDistanceKm,
+  yearDistanceKm,
+  yearNightsAway,
+  yearGeographicStats,
+  getFunComparisons,
+  getAchievementBadges,
+  getTravelPersonality,
+  getAvailableYears,
+  topCities,
+  topCountries,
+} from '../travelStats'
+
+// Paris and Rome are ~1105 km apart
+const PARIS = { id: '1', city: 'Paris', countryCode: 'FR', country: 'France', lat: 48.8566, lng: 2.3522, arrival: '2025-05-01', departure: '2025-05-06', type: 'vacation' }
+const ROME  = { id: '2', city: 'Rome',  countryCode: 'IT', country: 'Italy',  lat: 41.9028, lng: 12.4964, arrival: '2025-05-06', departure: '2025-05-11', type: 'vacation' }
+const TOKYO = { id: '3', city: 'Tokyo', countryCode: 'JP', country: 'Japan',  lat: 35.6762, lng: 139.6503, arrival: '2025-06-01', departure: '2025-06-08', type: 'business' }
+// No lat/lng — falls back to lookup table (London|GB exists)
+const LONDON_NO_COORDS = { id: '4', city: 'London', countryCode: 'GB', country: 'UK', arrival: '2025-07-01', departure: '2025-07-04', type: 'vacation' }
+
+describe('haversineKm', () => {
+  it('returns ~1105 km for Paris → Rome', () => {
+    const km = haversineKm(48.8566, 2.3522, 41.9028, 12.4964)
+    expect(km).toBeGreaterThan(1100)
+    expect(km).toBeLessThan(1115)
+  })
+
+  it('returns 0 for null inputs', () => {
+    expect(haversineKm(null, 2, 41, 12)).toBe(0)
+    expect(haversineKm(48, null, 41, 12)).toBe(0)
+  })
+
+  it('returns 0 for same point', () => {
+    expect(haversineKm(48.8566, 2.3522, 48.8566, 2.3522)).toBe(0)
+  })
+})
+
+describe('resolveCoords', () => {
+  it('returns exact coords when present', () => {
+    const result = resolveCoords(PARIS)
+    expect(result.lat).toBe(48.8566)
+    expect(result.approximate).toBe(false)
+  })
+
+  it('falls back to lookup table for London without coords', () => {
+    const result = resolveCoords(LONDON_NO_COORDS)
+    expect(result).not.toBeNull()
+    expect(result.approximate).toBe(true)
+    expect(result.lat).toBeCloseTo(51.5074, 0)
+  })
+
+  it('returns null for unknown city without coords', () => {
+    const unknown = { city: 'Zzyzx', countryCode: 'ZZ' }
+    expect(resolveCoords(unknown)).toBeNull()
+  })
+})
+
+describe('tripDistanceKm', () => {
+  it('calculates Paris → Rome distance', () => {
+    const { km, approximateCount, skippedCount } = tripDistanceKm([PARIS, ROME])
+    expect(km).toBeGreaterThan(1100)
+    expect(km).toBeLessThan(1115)
+    expect(approximateCount).toBe(0)
+    expect(skippedCount).toBe(0)
+  })
+
+  it('handles destinations with missing coords via fallback', () => {
+    const { km, approximateCount } = tripDistanceKm([PARIS, LONDON_NO_COORDS])
+    expect(km).toBeGreaterThan(300) // Paris → London ~340 km
+    expect(approximateCount).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for single destination', () => {
+    const { km } = tripDistanceKm([PARIS])
+    expect(km).toBe(0)
+  })
+
+  it('returns 0 for empty array', () => {
+    const { km } = tripDistanceKm([])
+    expect(km).toBe(0)
+  })
+})
+
+const TRIP_2025 = {
+  id: 't1',
+  destinations: [PARIS, ROME, TOKYO],
+  hotels: [], activities: [], transports: [],
+}
+const TRIP_2024 = {
+  id: 't2',
+  destinations: [
+    { ...PARIS, arrival: '2024-03-01', departure: '2024-03-06' },
+    { ...ROME,  arrival: '2024-03-06', departure: '2024-03-11' },
+  ],
+  hotels: [], activities: [], transports: [],
+}
+
+describe('yearDistanceKm', () => {
+  it('aggregates distance across trips for a year', () => {
+    const { km } = yearDistanceKm([TRIP_2025, TRIP_2024], 2025)
+    expect(km).toBeGreaterThan(10_000) // Paris→Rome + Rome→Tokyo is ~10,400 km
+  })
+
+  it('filters correctly by year', () => {
+    const { km: km2024 } = yearDistanceKm([TRIP_2025, TRIP_2024], 2024)
+    const { km: km2025 } = yearDistanceKm([TRIP_2025, TRIP_2024], 2025)
+    expect(km2024).toBeLessThan(km2025)
+  })
+
+  it('returns 0 for year with no trips', () => {
+    const { km } = yearDistanceKm([TRIP_2025], 2023)
+    expect(km).toBe(0)
+  })
+})
+
+describe('yearNightsAway', () => {
+  it('sums nights correctly', () => {
+    const { total, vacation, business } = yearNightsAway([TRIP_2025], 2025)
+    expect(total).toBe(17) // Paris 5 + Rome 5 + Tokyo 7
+    expect(vacation).toBe(10) // Paris + Rome
+    expect(business).toBe(7)  // Tokyo
+  })
+})
+
+describe('yearGeographicStats', () => {
+  it('returns correct country and continent counts', () => {
+    const stats = yearGeographicStats([TRIP_2025], 2025)
+    expect(stats.countryCodes).toContain('FR')
+    expect(stats.countryCodes).toContain('IT')
+    expect(stats.countryCodes).toContain('JP')
+    expect(stats.continents).toContain('Europe')
+    expect(stats.continents).toContain('Asia')
+    expect(stats.destinationCount).toBe(3)
+  })
+})
+
+describe('getFunComparisons', () => {
+  it('returns an array sorted closest to 1x first', () => {
+    const comps = getFunComparisons(28_450)
+    expect(comps.length).toBeGreaterThan(0)
+    // The first item should have a ratio closest to 1
+    if (comps.length > 1) {
+      expect(Math.abs(comps[0].ratio - 1)).toBeLessThanOrEqual(Math.abs(comps[1].ratio - 1))
+    }
+  })
+
+  it('returns empty for 0 km', () => {
+    expect(getFunComparisons(0)).toHaveLength(0)
+  })
+
+  it('generates correct text for ratio >= 1', () => {
+    // 21,196 km = exactly 1x Great Wall
+    const comps = getFunComparisons(21_196)
+    const gw = comps.find((c) => c.key === 'GREAT_WALL')
+    expect(gw).toBeDefined()
+    expect(gw.ratio).toBeCloseTo(1, 1)
+    expect(gw.text).toMatch(/traveled/)
+  })
+
+  it('generates percent text for ratio < 1', () => {
+    const comps = getFunComparisons(1_000)
+    const gw = comps.find((c) => c.key === 'GREAT_WALL')
+    expect(gw).toBeDefined()
+    expect(gw.text).toMatch(/%/)
+  })
+})
+
+describe('getAchievementBadges', () => {
+  it('always returns 9 badges', () => {
+    expect(getAchievementBadges({ km: 0, nightsAway: 0, countryCodes: [], continents: [], destinationCount: 0 })).toHaveLength(9)
+  })
+
+  it('earns 10K Club at km >= 10000', () => {
+    const badges = getAchievementBadges({ km: 10_001, nightsAway: 0, countryCodes: [], continents: [], destinationCount: 1 })
+    expect(badges.find((b) => b.id === 'globetrotter_10k').earned).toBe(true)
+  })
+
+  it('does not earn 10K Club below threshold', () => {
+    const badges = getAchievementBadges({ km: 9_999, nightsAway: 0, countryCodes: [], continents: [], destinationCount: 1 })
+    expect(badges.find((b) => b.id === 'globetrotter_10k').earned).toBe(false)
+  })
+
+  it('earns Five Flags at 5+ countries', () => {
+    const badges = getAchievementBadges({ km: 0, nightsAway: 0, countryCodes: ['FR','IT','JP','US','DE'], continents: [], destinationCount: 5 })
+    expect(badges.find((b) => b.id === 'five_countries').earned).toBe(true)
+  })
+})
+
+describe('getTravelPersonality', () => {
+  it('returns a non-null personality when there are destinations', () => {
+    const geo = { nightsAway: 30, vacationNights: 20, businessNights: 10, destinationCount: 4, countryCodes: ['FR','IT','DE'] }
+    const dist = { km: 8_000 }
+    expect(getTravelPersonality(geo, dist)).not.toBeNull()
+  })
+
+  it('returns null when no destinations', () => {
+    const geo = { nightsAway: 0, vacationNights: 0, businessNights: 0, destinationCount: 0, countryCodes: [] }
+    expect(getTravelPersonality(geo, { km: 0 })).toBeNull()
+  })
+})
+
+describe('getAvailableYears', () => {
+  it('extracts years from trip destinations', () => {
+    const years = getAvailableYears([TRIP_2025, TRIP_2024])
+    expect(years).toContain(2025)
+    expect(years).toContain(2024)
+    // Sorted descending
+    expect(years[0]).toBeGreaterThanOrEqual(years[1])
+  })
+
+  it('returns current year for empty trips', () => {
+    const years = getAvailableYears([])
+    expect(years).toHaveLength(1)
+    expect(years[0]).toBe(new Date().getFullYear())
+  })
+})
+
+describe('topCities and topCountries', () => {
+  const tripsWithRepeat = [
+    { ...TRIP_2025 },
+    { id: 't3', destinations: [{ ...PARIS, id: '5', arrival: '2024-01-01', departure: '2024-01-05' }], hotels: [], activities: [], transports: [] },
+  ]
+
+  it('ranks cities by visit count', () => {
+    const cities = topCities(tripsWithRepeat, 3)
+    expect(cities[0].city).toBe('Paris') // 2 visits
+    expect(cities[0].visits).toBe(2)
+  })
+
+  it('ranks countries by visit count', () => {
+    const countries = topCountries(tripsWithRepeat, 3)
+    expect(countries[0].countryCode).toBe('FR') // Paris visited twice
+  })
+})

--- a/src/utils/travelStats.js
+++ b/src/utils/travelStats.js
@@ -1,0 +1,376 @@
+import { differenceInDays, startOfDay } from 'date-fns'
+
+// ── Haversine ─────────────────────────────────────────────────────────────────
+
+export function haversineKm(lat1, lng1, lat2, lng2) {
+  if (lat1 == null || lng1 == null || lat2 == null || lng2 == null) return 0
+  const R = 6371
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLng = ((lng2 - lng1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2)
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+// ── Static city coordinate fallback table ─────────────────────────────────────
+// Key format: "city|CC" (lowercase city, uppercase country code)
+
+const CITY_COORDS = {
+  'london|GB':      [51.5074, -0.1278],  'paris|FR':       [48.8566,  2.3522],
+  'new york|US':    [40.7128,-74.0060],  'tokyo|JP':       [35.6762,139.6503],
+  'rome|IT':        [41.9028, 12.4964],  'berlin|DE':      [52.5200, 13.4050],
+  'madrid|ES':      [40.4168, -3.7038],  'barcelona|ES':   [41.3851,  2.1734],
+  'amsterdam|NL':   [52.3676,  4.9041],  'vienna|AT':      [48.2082, 16.3738],
+  'prague|CZ':      [50.0755, 14.4378],  'budapest|HU':    [47.4979, 19.0402],
+  'lisbon|PT':      [38.7169, -9.1395],  'athens|GR':      [37.9838, 23.7275],
+  'istanbul|TR':    [41.0082, 28.9784],  'moscow|RU':      [55.7558, 37.6176],
+  'dubai|AE':       [25.2048, 55.2708],  'singapore|SG':   [1.3521,  103.8198],
+  'sydney|AU':      [-33.8688,151.2093], 'melbourne|AU':   [-37.8136,144.9631],
+  'toronto|CA':     [43.6532,-79.3832],  'vancouver|CA':   [49.2827,-123.1207],
+  'los angeles|US': [34.0522,-118.2437], 'chicago|US':     [41.8781,-87.6298],
+  'miami|US':       [25.7617,-80.1918],  'san francisco|US':[37.7749,-122.4194],
+  'seattle|US':     [47.6062,-122.3321], 'boston|US':      [42.3601,-71.0589],
+  'washington|US':  [38.9072,-77.0369],  'las vegas|US':   [36.1699,-115.1398],
+  'mexico city|MX': [19.4326,-99.1332],  'cancun|MX':      [21.1619,-86.8515],
+  'sao paulo|BR':   [-23.5505,-46.6333], 'rio de janeiro|BR':[-22.9068,-43.1729],
+  'buenos aires|AR':[-34.6037,-58.3816], 'bogota|CO':      [4.7110,-74.0721],
+  'lima|PE':        [-12.0464,-77.0428], 'santiago|CL':    [-33.4489,-70.6693],
+  'cairo|EG':       [30.0444, 31.2357],  'nairobi|KE':     [-1.2921, 36.8219],
+  'johannesburg|ZA':[-26.2041, 28.0473], 'cape town|ZA':   [-33.9249, 18.4241],
+  'lagos|NG':       [6.5244,   3.3792],  'casablanca|MA':  [33.5731, -7.5898],
+  'mumbai|IN':      [19.0760, 72.8777],  'delhi|IN':       [28.6139, 77.2090],
+  'bangalore|IN':   [12.9716, 77.5946],  'kolkata|IN':     [22.5726, 88.3639],
+  'beijing|CN':     [39.9042,116.4074],  'shanghai|CN':    [31.2304,121.4737],
+  'hong kong|HK':   [22.3193,114.1694],  'seoul|KR':       [37.5665,126.9780],
+  'bangkok|TH':     [13.7563,100.5018],  'jakarta|ID':     [-6.2088,106.8456],
+  'kuala lumpur|MY':[3.1390, 101.6869],  'manila|PH':      [14.5995,120.9842],
+  'hanoi|VN':       [21.0285,105.8542],  'ho chi minh city|VN':[10.8231,106.6297],
+  'taipei|TW':      [25.0330,121.5654],  'osaka|JP':       [34.6937,135.5023],
+  'kyoto|JP':       [35.0116,135.7681],  'auckland|NZ':    [-36.8485,174.7633],
+  'bali|ID':        [-8.3405,115.0920],  'phuket|TH':      [7.8804, 98.3923],
+  'dubai|AE':       [25.2048, 55.2708],  'abu dhabi|AE':   [24.4539, 54.3773],
+  'doha|QA':        [25.2854, 51.5310],  'riyadh|SA':      [24.7136, 46.6753],
+  'tel aviv|IL':    [32.0853, 34.7818],  'amman|JO':       [31.9539, 35.9106],
+  'stockholm|SE':   [59.3293, 18.0686],  'oslo|NO':        [59.9139, 10.7522],
+  'copenhagen|DK':  [55.6761, 12.5683],  'helsinki|FI':    [60.1699, 24.9384],
+  'zurich|CH':      [47.3769,  8.5417],  'geneva|CH':      [46.2044,  6.1432],
+  'brussels|BE':    [50.8503,  4.3517],  'warsaw|PL':       [52.2297, 21.0122],
+  'bucharest|RO':   [44.4268, 26.1025],  'sofia|BG':       [42.6977, 23.3219],
+  'zagreb|HR':      [45.8150, 15.9819],  'dubrovnik|HR':   [42.6507, 18.0944],
+  'edinburgh|GB':   [55.9533, -3.1883],  'dublin|IE':      [53.3498, -6.2603],
+  'lisbon|PT':      [38.7169, -9.1395],  'porto|PT':       [41.1579, -8.6291],
+  'seville|ES':     [37.3891, -5.9845],  'florence|IT':    [43.7696, 11.2558],
+  'venice|IT':      [45.4408, 12.3155],  'milan|IT':       [45.4642,  9.1900],
+  'munich|DE':      [48.1351, 11.5820],  'frankfurt|DE':   [50.1109,  8.6821],
+  'hamburg|DE':     [53.5753,  10.0153], 'cologne|DE':     [50.9333,  6.9500],
+  'zurich|CH':      [47.3769,  8.5417],  'bern|CH':        [46.9480,  7.4474],
+  'reykjavik|IS':   [64.1466,-21.9426],  'valletta|MT':    [35.8997, 14.5147],
+  'nicosia|CY':     [35.1676, 33.3736],  'bratislava|SK':  [48.1486, 17.1077],
+  'ljubljana|SI':   [46.0569, 14.5058],  'sarajevo|BA':    [43.8563, 18.4131],
+  'montreal|CA':    [45.5017,-73.5673],  'calgary|CA':     [51.0447,-114.0719],
+  'honolulu|US':    [21.3069,-157.8583], 'denver|US':      [39.7392,-104.9903],
+  'atlanta|US':     [33.7490,-84.3880],  'dallas|US':      [32.7767,-96.7970],
+  'houston|US':     [29.7604,-95.3698],  'phoenix|US':     [33.4484,-112.0740],
+  'portland|US':    [45.5051,-122.6750], 'minneapolis|US': [44.9778,-93.2650],
+  'nashville|US':   [36.1627,-86.7816],  'new orleans|US': [29.9511,-90.0715],
+  'havana|CU':      [23.1136,-82.3666],  'panama city|PA': [8.9936,-79.5197],
+  'san jose|CR':    [9.9281,-84.0907],   'guatemala city|GT':[14.6349,-90.5069],
+  'quito|EC':       [-0.2295,-78.5243],  'la paz|BO':      [-16.5000,-68.1500],
+  'montevideo|UY':  [-34.9011,-56.1645], 'asuncion|PY':    [-25.2867,-57.6470],
+  'caracas|VE':     [10.4806,-66.9036],  'medellin|CO':    [6.2442,-75.5812],
+  'marrakech|MA':   [31.6295,-7.9811],   'tunis|TN':       [36.8190, 10.1658],
+  'algiers|DZ':     [36.7372,  3.0865],  'accra|GH':       [5.6037,  -0.1870],
+  'addis ababa|ET': [9.0300,  38.7400],  'dar es salaam|TZ':[-6.7924, 39.2083],
+  'kampala|UG':     [0.3476,  32.5825],  'kigali|RW':      [-1.9441, 30.0619],
+  'lusaka|ZM':      [-15.4167, 28.2833], 'harare|ZW':      [-17.8292, 31.0522],
+  'maputo|MZ':      [-25.9692, 32.5732], 'windhoek|NA':    [-22.5597, 17.0832],
+  'gaborone|BW':    [-24.6282, 25.9231], 'antananarivo|MG':[-18.9137, 47.5361],
+  'colombo|LK':     [6.9271,  79.8612],  'kathmandu|NP':   [27.7172, 85.3240],
+  'dhaka|BD':       [23.8103, 90.4125],  'karachi|PK':     [24.8607, 67.0011],
+  'lahore|PK':      [31.5204, 74.3587],  'islamabad|PK':   [33.6844, 73.0479],
+  'tashkent|UZ':    [41.2995, 69.2401],  'almaty|KZ':      [43.2220, 76.8512],
+  'tbilisi|GE':     [41.6938, 44.8015],  'yerevan|AM':     [40.1872, 44.5152],
+  'baku|AZ':        [40.4093, 49.8671],  'minsk|BY':       [53.9006, 27.5590],
+  'riga|LV':        [56.9460, 24.1059],  'tallinn|EE':     [59.4370, 24.7536],
+  'vilnius|LT':     [54.6872, 25.2797],  'kyiv|UA':        [50.4501, 30.5234],
+  'chisinau|MD':    [47.0105, 28.8638],  'tirana|AL':      [41.3275, 19.8187],
+  'skopje|MK':      [41.9961, 21.4316],  'podgorica|ME':   [42.4304, 19.2594],
+  'pristina|XK':    [42.6629, 21.1655],  'belgrade|RS':    [44.8176, 20.4569],
+}
+
+export function lookupCityCoords(dest) {
+  const key = `${(dest.city || '').toLowerCase()}|${(dest.countryCode || '').toUpperCase()}`
+  const coords = CITY_COORDS[key]
+  return coords ? { lat: coords[0], lng: coords[1] } : null
+}
+
+export function resolveCoords(dest) {
+  if (dest.lat != null && dest.lng != null) return { lat: dest.lat, lng: dest.lng, approximate: false }
+  const fallback = lookupCityCoords(dest)
+  if (fallback) return { ...fallback, approximate: true }
+  return null
+}
+
+// ── Distance ──────────────────────────────────────────────────────────────────
+
+export function tripDistanceKm(destinations) {
+  const sorted = [...(destinations || [])].sort(
+    (a, b) => new Date(a.arrival) - new Date(b.arrival)
+  )
+  let km = 0
+  let approximateCount = 0
+  let skippedCount = 0
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const a = resolveCoords(sorted[i])
+    const b = resolveCoords(sorted[i + 1])
+    if (!a || !b) { skippedCount++; continue }
+    km += haversineKm(a.lat, a.lng, b.lat, b.lng)
+    if (a.approximate || b.approximate) approximateCount++
+  }
+  return { km, approximateCount, skippedCount }
+}
+
+export function yearDistanceKm(trips, year) {
+  let km = 0
+  let approximateCount = 0
+  let skippedCount = 0
+  for (const trip of trips || []) {
+    const dests = (trip.destinations || []).filter(
+      (d) => new Date(d.arrival).getFullYear() === year
+    )
+    if (dests.length < 2) continue
+    const result = tripDistanceKm(dests)
+    km += result.km
+    approximateCount += result.approximateCount
+    skippedCount += result.skippedCount
+  }
+  return { km, approximateCount, skippedCount }
+}
+
+// ── Geography ─────────────────────────────────────────────────────────────────
+
+export function uniqueCountries(destinations) {
+  return [...new Set((destinations || []).map((d) => d.countryCode).filter(Boolean))].sort()
+}
+
+const CONTINENT_MAP = {
+  AF:'Africa',DZ:'Africa',AO:'Africa',BJ:'Africa',BW:'Africa',BF:'Africa',
+  BI:'Africa',CM:'Africa',CV:'Africa',CF:'Africa',TD:'Africa',KM:'Africa',
+  CG:'Africa',CD:'Africa',CI:'Africa',DJ:'Africa',EG:'Africa',GQ:'Africa',
+  ER:'Africa',ET:'Africa',GA:'Africa',GM:'Africa',GH:'Africa',GN:'Africa',
+  GW:'Africa',KE:'Africa',LS:'Africa',LR:'Africa',LY:'Africa',MG:'Africa',
+  MW:'Africa',ML:'Africa',MR:'Africa',MU:'Africa',YT:'Africa',MA:'Africa',
+  MZ:'Africa',NA:'Africa',NE:'Africa',NG:'Africa',RE:'Africa',RW:'Africa',
+  SH:'Africa',ST:'Africa',SN:'Africa',SC:'Africa',SL:'Africa',SO:'Africa',
+  ZA:'Africa',SS:'Africa',SD:'Africa',SZ:'Africa',TZ:'Africa',TG:'Africa',
+  TN:'Africa',UG:'Africa',EH:'Africa',ZM:'Africa',ZW:'Africa',
+  DZ:'Africa',
+  AS:'Oceania',AU:'Oceania',CK:'Oceania',FJ:'Oceania',PF:'Oceania',
+  GU:'Oceania',KI:'Oceania',MH:'Oceania',FM:'Oceania',NR:'Oceania',
+  NC:'Oceania',NZ:'Oceania',NU:'Oceania',MP:'Oceania',PW:'Oceania',
+  PG:'Oceania',PN:'Oceania',WS:'Oceania',SB:'Oceania',TK:'Oceania',
+  TO:'Oceania',TV:'Oceania',VU:'Oceania',WF:'Oceania',
+  AQ:'Antarctica',
+  AM:'Asia',AZ:'Asia',BH:'Asia',BD:'Asia',BT:'Asia',IO:'Asia',BN:'Asia',
+  KH:'Asia',CN:'Asia',CX:'Asia',CC:'Asia',CY:'Asia',GE:'Asia',HK:'Asia',
+  IN:'Asia',ID:'Asia',IR:'Asia',IQ:'Asia',IL:'Asia',JP:'Asia',JO:'Asia',
+  KZ:'Asia',KW:'Asia',KG:'Asia',LA:'Asia',LB:'Asia',MO:'Asia',MY:'Asia',
+  MV:'Asia',MN:'Asia',MM:'Asia',NP:'Asia',KP:'Asia',OM:'Asia',PK:'Asia',
+  PS:'Asia',PH:'Asia',QA:'Asia',SA:'Asia',SG:'Asia',KR:'Asia',LK:'Asia',
+  SY:'Asia',TW:'Asia',TJ:'Asia',TH:'Asia',TL:'Asia',TR:'Asia',TM:'Asia',
+  AE:'Asia',UZ:'Asia',VN:'Asia',YE:'Asia',
+  AL:'Europe',AD:'Europe',AT:'Europe',BY:'Europe',BE:'Europe',BA:'Europe',
+  BG:'Europe',HR:'Europe',CY:'Europe',CZ:'Europe',DK:'Europe',EE:'Europe',
+  FO:'Europe',FI:'Europe',FR:'Europe',DE:'Europe',GI:'Europe',GR:'Europe',
+  GG:'Europe',HU:'Europe',IS:'Europe',IE:'Europe',IM:'Europe',IT:'Europe',
+  JE:'Europe',XK:'Europe',LV:'Europe',LI:'Europe',LT:'Europe',LU:'Europe',
+  MK:'Europe',MT:'Europe',MD:'Europe',MC:'Europe',ME:'Europe',NL:'Europe',
+  NO:'Europe',PL:'Europe',PT:'Europe',RO:'Europe',RU:'Europe',SM:'Europe',
+  RS:'Europe',SK:'Europe',SI:'Europe',ES:'Europe',SE:'Europe',CH:'Europe',
+  UA:'Europe',GB:'Europe',VA:'Europe',
+  AI:'Americas',AG:'Americas',AR:'Americas',AW:'Americas',BS:'Americas',
+  BB:'Americas',BZ:'Americas',BM:'Americas',BO:'Americas',BQ:'Americas',
+  BR:'Americas',VG:'Americas',CA:'Americas',KY:'Americas',CL:'Americas',
+  CO:'Americas',CR:'Americas',CU:'Americas',CW:'Americas',DM:'Americas',
+  DO:'Americas',EC:'Americas',SV:'Americas',FK:'Americas',GF:'Americas',
+  GL:'Americas',GD:'Americas',GP:'Americas',GT:'Americas',GY:'Americas',
+  HT:'Americas',HN:'Americas',JM:'Americas',MQ:'Americas',MX:'Americas',
+  MS:'Americas',NI:'Americas',PA:'Americas',PY:'Americas',PE:'Americas',
+  PR:'Americas',BL:'Americas',KN:'Americas',LC:'Americas',MF:'Americas',
+  PM:'Americas',VC:'Americas',SX:'Americas',SR:'Americas',TT:'Americas',
+  TC:'Americas',US:'Americas',UY:'Americas',VE:'Americas',VI:'Americas',
+}
+
+export function countryToContinent(countryCode) {
+  return CONTINENT_MAP[countryCode] ?? 'Unknown'
+}
+
+export function uniqueContinents(destinations) {
+  return [...new Set(uniqueCountries(destinations).map(countryToContinent))].sort()
+}
+
+export function yearNightsAway(trips, year) {
+  let total = 0, vacation = 0, business = 0
+  for (const trip of trips || []) {
+    for (const d of trip.destinations || []) {
+      if (new Date(d.arrival).getFullYear() !== year) continue
+      const nights = differenceInDays(startOfDay(new Date(d.departure)), startOfDay(new Date(d.arrival)))
+      if (nights <= 0) continue
+      total += nights
+      if (d.type === 'vacation') vacation += nights
+      else business += nights
+    }
+  }
+  return { total, vacation, business }
+}
+
+export function yearGeographicStats(trips, year) {
+  const allDests = (trips || []).flatMap((t) =>
+    (t.destinations || []).filter((d) => new Date(d.arrival).getFullYear() === year)
+  )
+  const tripsWithYear = (trips || []).filter((t) =>
+    (t.destinations || []).some((d) => new Date(d.arrival).getFullYear() === year)
+  )
+  const countryCodes = uniqueCountries(allDests)
+  const continents = uniqueContinents(allDests)
+  const { total, vacation, business } = yearNightsAway(trips, year)
+  return {
+    countryCodes,
+    countries: countryCodes.map((cc) => allDests.find((d) => d.countryCode === cc)?.country ?? cc),
+    continents,
+    nightsAway: total,
+    vacationNights: vacation,
+    businessNights: business,
+    destinationCount: allDests.length,
+    tripCount: tripsWithYear.length,
+  }
+}
+
+export function getAvailableYears(trips) {
+  const years = new Set()
+  for (const trip of trips || []) {
+    for (const d of trip.destinations || []) {
+      const y = new Date(d.arrival).getFullYear()
+      if (!isNaN(y)) years.add(y)
+    }
+  }
+  return years.size > 0 ? [...years].sort((a, b) => b - a) : [new Date().getFullYear()]
+}
+
+// ── Fun comparisons ───────────────────────────────────────────────────────────
+
+export const REFERENCE_DISTANCES = {
+  GREAT_BARRIER_REEF:  { km: 2_300,   label: 'Great Barrier Reef',          emoji: '🪸' },
+  SILK_ROAD:           { km: 6_400,   label: 'ancient Silk Road',           emoji: '🐪' },
+  AMAZON_RIVER:        { km: 6_992,   label: 'Amazon River',                emoji: '🌿' },
+  TRANS_SIBERIAN:      { km: 9_289,   label: 'Trans-Siberian Railway',      emoji: '🚂' },
+  NYC_TO_LA:           { km: 4_486,   label: 'New York to Los Angeles',     emoji: '🗽' },
+  SAHARA_DESERT:       { km: 4_800,   label: 'width of the Sahara Desert',  emoji: '🏜' },
+  GREAT_WALL:          { km: 21_196,  label: 'Great Wall of China',         emoji: '🏯' },
+  ROMAN_ROAD_NETWORK:  { km: 80_000,  label: 'Roman road network',          emoji: '🏛' },
+  EARTH_CIRCUMFERENCE: { km: 40_075,  label: 'Earth circumference',         emoji: '🌍' },
+  PACIFIC_OCEAN:       { km: 12_300,  label: 'Pacific Ocean (widest)',      emoji: '🌊' },
+  MOON_DISTANCE:       { km: 384_400, label: 'Earth to the Moon',           emoji: '🌕' },
+}
+
+export function getFunComparisons(km) {
+  if (!km || km <= 0) return []
+  return Object.entries(REFERENCE_DISTANCES)
+    .map(([key, ref]) => {
+      const ratio = km / ref.km
+      const rounded = Math.round(ratio * 100) / 100
+      let text
+      if (key === 'EARTH_CIRCUMFERENCE') {
+        text = ratio >= 1
+          ? `You could have circled the Earth ${rounded}× times`
+          : `You've covered ${Math.round(ratio * 100)}% of Earth's circumference`
+      } else if (key === 'MOON_DISTANCE') {
+        text = `You're ${Math.round(ratio * 100)}% of the way to the Moon`
+      } else if (ratio >= 1) {
+        text = `You've traveled ${rounded}× the ${ref.label}`
+      } else {
+        text = `You've covered ${Math.round(ratio * 100)}% of the ${ref.label}`
+      }
+      return { key, label: ref.label, emoji: ref.emoji, ratio: rounded, text }
+    })
+    .filter((c) => c.ratio >= 0.05 && c.ratio <= 999)
+    .sort((a, b) => Math.abs(a.ratio - 1) - Math.abs(b.ratio - 1))
+}
+
+// ── Achievement badges ────────────────────────────────────────────────────────
+
+const BADGE_DEFS = [
+  { id: 'first_flight',      label: 'Jet-setter Begins',  emoji: '✈',  description: 'First destination added',              tier: 'bronze', test: (s) => s.destinationCount >= 1 },
+  { id: 'globetrotter_10k',  label: '10K Club',           emoji: '🚀', description: '10,000 km traveled in a year',         tier: 'bronze', test: (s) => s.km >= 10_000 },
+  { id: 'night_owl_30',      label: 'Month Away',         emoji: '🌙', description: '30 nights away in a year',             tier: 'bronze', test: (s) => s.nightsAway >= 30 },
+  { id: 'multi_continent',   label: 'Continental Drift',  emoji: '🗺',  description: 'Visited 2+ continents in a year',      tier: 'bronze', test: (s) => s.continents.length >= 2 },
+  { id: 'five_countries',    label: 'Five Flags',         emoji: '🎌', description: '5 countries visited in a year',        tier: 'silver', test: (s) => s.countryCodes.length >= 5 },
+  { id: 'globetrotter_50k',  label: '50K Voyager',        emoji: '🌐', description: '50,000 km traveled in a year',         tier: 'silver', test: (s) => s.km >= 50_000 },
+  { id: 'night_owl_90',      label: 'Quarter Nomad',      emoji: '🎒', description: '90 nights away in a year',             tier: 'silver', test: (s) => s.nightsAway >= 90 },
+  { id: 'ten_countries',     label: 'Ten Flags',          emoji: '🏆', description: '10 countries visited in a year',       tier: 'gold',   test: (s) => s.countryCodes.length >= 10 },
+  { id: 'globetrotter_100k', label: 'Century Traveler',   emoji: '👑', description: '100,000 km traveled in a year',        tier: 'gold',   test: (s) => s.km >= 100_000 },
+]
+
+export function getAchievementBadges(stats) {
+  return BADGE_DEFS.map(({ test, ...def }) => ({ ...def, earned: test(stats) }))
+}
+
+// ── Travel personality ────────────────────────────────────────────────────────
+
+export function getTravelPersonality(geo, distResult) {
+  const { nightsAway, vacationNights, businessNights, destinationCount, countryCodes } = geo
+  const { km } = distResult
+  if (!destinationCount) return null
+  const businessRatio = nightsAway > 0 ? businessNights / nightsAway : 0
+  const avgStay = destinationCount > 0 ? nightsAway / destinationCount : 0
+  if (businessRatio > 0.6 && km > 5_000)
+    return { type: 'business_jet_setter', label: 'Business Jet-Setter', emoji: '💼', description: 'Your passport is basically a work permit.' }
+  if (countryCodes.length >= 5 && avgStay < 5)
+    return { type: 'culture_hopper', label: 'Culture Hopper', emoji: '🎭', description: 'You collect countries like souvenirs.' }
+  if (nightsAway >= 60 && avgStay > 10)
+    return { type: 'nomad', label: 'Nomad', emoji: '🏕', description: 'Home is wherever you unpack.' }
+  if (destinationCount >= 6 && nightsAway < 30)
+    return { type: 'weekend_escaper', label: 'Weekend Escaper', emoji: '⚡', description: 'Maximum destinations, minimum days off.' }
+  if (km > 30_000)
+    return { type: 'long_hauler', label: 'Long-Hauler', emoji: '🌏', description: 'You eat time zones for breakfast.' }
+  return { type: 'explorer', label: 'Explorer', emoji: '🧭', description: 'Every trip is an adventure in the making.' }
+}
+
+// ── Year-over-year ────────────────────────────────────────────────────────────
+
+export function multiYearKm(trips, years) {
+  return years.map((year) => ({ year, ...yearDistanceKm(trips, year) }))
+}
+
+// ── Top cities / countries ────────────────────────────────────────────────────
+
+export function topCities(trips, limit = 5) {
+  const map = {}
+  for (const trip of trips || []) {
+    for (const d of trip.destinations || []) {
+      const key = `${d.city}|${d.countryCode}`
+      if (!map[key]) map[key] = { city: d.city, countryCode: d.countryCode, country: d.country, visits: 0, nights: 0 }
+      map[key].visits++
+      map[key].nights += Math.max(0, differenceInDays(startOfDay(new Date(d.departure)), startOfDay(new Date(d.arrival))))
+    }
+  }
+  return Object.values(map).sort((a, b) => b.visits - a.visits || b.nights - a.nights).slice(0, limit)
+}
+
+export function topCountries(trips, limit = 5) {
+  const map = {}
+  for (const trip of trips || []) {
+    for (const d of trip.destinations || []) {
+      const key = d.countryCode
+      if (!key) continue
+      if (!map[key]) map[key] = { countryCode: key, country: d.country, visits: 0, nights: 0 }
+      map[key].visits++
+      map[key].nights += Math.max(0, differenceInDays(startOfDay(new Date(d.departure)), startOfDay(new Date(d.arrival))))
+    }
+  }
+  return Object.values(map).sort((a, b) => b.visits - a.visits || b.nights - a.nights).slice(0, limit)
+}


### PR DESCRIPTION
## Summary

- **Travel Stats panel** (📊 button in header) showing km traveled, nights away, countries/continents, and year-over-year sparkline
- **Fun distance comparisons** carousel — "You've covered 14% of the Great Wall of China", "You've traveled 1.3× the Trans-Siberian Railway", etc.
- **Achievement badges** (9 total across bronze/silver/gold tiers) based on km, nights, countries, and continents
- **Travel personality** archetype — Culture Hopper, Nomad, Business Jet-Setter, etc.
- **Community percentile** — sign in and publish your anonymous stats to see how you rank against other Wayfar travelers (requires the `community_stats` Supabase table — SQL below)
- **All-time favourites** — top cities and countries across all trips
- **Demo updated**: `/?demo` now seeds two trips (Europe 2026 + Asia 2025) with exact coordinates so the stats panel is fully populated out of the box

## Supabase migration required

Run this in your Supabase SQL Editor before deploying:

```sql
create table community_stats (
  id              uuid      default gen_random_uuid() primary key,
  user_id         uuid      not null references auth.users(id) on delete cascade,
  year            smallint  not null,
  km_traveled     integer   not null default 0,
  nights_away     smallint  not null default 0,
  country_count   smallint  not null default 0,
  continent_count smallint  not null default 0,
  dest_count      smallint  not null default 0,
  published_at    timestamptz default now(),
  unique (user_id, year)
);

alter table community_stats enable row level security;

create policy "own row" on community_stats
  using (auth.uid() = user_id)
  with check (auth.uid() = user_id);

create or replace function get_travel_percentile(p_km integer, p_year smallint)
returns json language sql security definer stable as $$
  select json_build_object(
    'percentile',  round(100.0 * count(*) filter (where km_traveled < p_km) / nullif(count(*), 0)),
    'avg_km',      round(avg(km_traveled)),
    'median_km',   percentile_cont(0.5) within group (order by km_traveled),
    'sample_size', count(*),
    'p75_km',      percentile_cont(0.75) within group (order by km_traveled),
    'p90_km',      percentile_cont(0.90) within group (order by km_traveled)
  )
  from community_stats
  where year = p_year and km_traveled > 0;
$$;
```

## Test plan

- [ ] Visit `/?demo` → two trips load (Europe Demo + Asia 2025)
- [ ] Click 📊 button in header → Travel Stats panel slides in
- [ ] Switch between 2025 and 2026 year pills — stats update
- [ ] Fun comparison carousel — ◄ ► arrows cycle through comparisons
- [ ] Achievement badges appear for earned tiers
- [ ] Guest: community section shows "Sign in to compare" prompt
- [ ] Signed-in user: "Publish my stats" button appears → after publish, percentile rank shows

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr