### PR TITLE
feat: social travel stats, UX improvements, and mobile enhancements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { uuid } from './lib/uuid'
 import { format, differenceInDays, startOfDay } from 'date-fns'
 import QuickStartModal from './components/quickstart/QuickStartModal'
+import InlineDestinationCreator from './components/InlineDestinationCreator'
 import CollaborationModal from './components/CollaborationModal'
 import { useCollaboration } from './hooks/useCollaboration'
 import Timeline from './components/Timeline'
@@ -108,6 +109,9 @@ export default function App() {
   const [hotelsOpen, setHotelsOpen] = useState(true)
   const [transportsOpen, setTransportsOpen] = useState(true)
   const twoColRef = useRef(null)
+  const [undoSnapshot, setUndoSnapshot] = useState(null)
+  const [undoVisible, setUndoVisible] = useState(false)
+  const undoTimerRef = useRef(null)
 
   // Persist to localStorage
   useEffect(() => {
@@ -191,6 +195,47 @@ export default function App() {
   }
   const renameTrip = (id, name) => {
     setTrips((prev) => prev.map((t) => (t.id === id ? { ...t, name } : t)))
+  }
+
+  // ── Undo ──
+  const snapshotForUndo = useCallback(() => {
+    setUndoSnapshot({ trips, activeTripId })
+  }, [trips, activeTripId])
+
+  const showUndoToast = useCallback(() => {
+    setUndoVisible(true)
+    clearTimeout(undoTimerRef.current)
+    undoTimerRef.current = setTimeout(() => setUndoVisible(false), 5000)
+  }, [])
+
+  const handleUndo = () => {
+    if (undoSnapshot) {
+      setTrips(undoSnapshot.trips)
+      setActiveTripId(undoSnapshot.activeTripId)
+    }
+    setUndoVisible(false)
+    clearTimeout(undoTimerRef.current)
+  }
+
+  // ── Inline first-destination creator ──
+  const handleInlineAdd = ({ city, arrival, departure }) => {
+    const dest = {
+      id: uuid(),
+      city: city.city,
+      country: city.country,
+      countryCode: city.countryCode,
+      lat: city.lat ?? null,
+      lng: city.lng ?? null,
+      arrival,
+      departure,
+      type: 'vacation',
+    }
+    const newTrip = makeTrip(city.city, { destinations: [dest] })
+    setTrips((prev) => {
+      const existing = prev.filter((t) => !(t.name === 'My Trip' && t.destinations.length === 0))
+      return [...existing, newTrip]
+    })
+    setActiveTripId(newTrip.id)
   }
 
   // ── Destinations ──
@@ -481,18 +526,7 @@ export default function App() {
       {/* ── Main ── */}
       <main className="relative z-10 max-w-6xl mx-auto px-4 sm:px-8 py-6 sm:py-8 dark:text-gray-100">
         {!hasData ? (
-          <div className="flex flex-col items-center justify-center py-40 gap-4">
-            <div className="text-3xl" style={{ filter: 'grayscale(1)', opacity: 0.18 }}>✈</div>
-            <div className="text-center">
-              <p className="text-sm text-gray-400 mb-1">No trips planned yet</p>
-              <p className="text-xs text-gray-300">Let's get you somewhere.</p>
-            </div>
-            <button
-              onClick={() => setShowQuickStart(true)}
-              data-testid="plan-a-trip-button"
-              className="text-sm border border-gray-200 px-5 py-2.5 rounded-xl hover:bg-gray-50 transition-colors text-gray-500 font-medium"
-            >Plan a trip →</button>
-          </div>
+          <InlineDestinationCreator onAdd={handleInlineAdd} />
         ) : (
           <>
             {/* Timeline */}
@@ -519,6 +553,8 @@ export default function App() {
                 onClickTransport={openTransportCard}
                 onEditTransport={(t) => setModal({ type: 'transport', editing: t })}
                 onDeleteTransport={deleteTransport}
+                onDragStart={snapshotForUndo}
+                onDragComplete={showUndoToast}
               />
             </section>
 
@@ -713,6 +749,9 @@ export default function App() {
         <AddDestinationModal
           editing={modal.editing}
           destinations={destinations}
+          lastDeparture={!modal.editing && destinations.length > 0
+            ? [...destinations].sort((a, b) => a.departure < b.departure ? 1 : -1)[0].departure
+            : ''}
           onAdd={addDestination}
           onUpdate={(updates) => { updateDestination(modal.editing.id, updates); setModal(null) }}
           onClose={() => setModal(null)}
@@ -728,6 +767,9 @@ export default function App() {
         <HotelModal
           editing={modal.editing}
           hotels={hotels}
+          activeDestination={!modal.editing ? (destinations.length > 0
+            ? [...destinations].sort((a, b) => a.departure < b.departure ? 1 : -1)[0]
+            : null) : null}
           onSave={(data) => { if (data.id) updateHotel(data.id, data); else addHotel(data) }}
           onClose={() => setModal(null)}
         />
@@ -759,6 +801,23 @@ export default function App() {
         />
       )}
       <DetailCard item={selectedItem} onClose={() => setSelectedItem(null)} onEdit={handleDetailEdit} />
+
+      {/* Mobile FAB — add destination */}
+      <button
+        onClick={() => setModal({ type: 'destination', editing: null })}
+        className="sm:hidden fixed bottom-6 right-6 z-40 w-14 h-14 rounded-full bg-sky-500 text-white text-3xl shadow-lg flex items-center justify-center hover:bg-sky-600 active:scale-95 transition-all"
+        aria-label="Add destination"
+      >+</button>
+
+      {/* Undo toast */}
+      {undoVisible && (
+        <div className="fixed bottom-24 sm:bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm rounded-xl px-4 py-2.5 shadow-lg">
+          <span>Move applied</span>
+          <button onClick={handleUndo} className="font-semibold underline">Undo</button>
+          <button onClick={() => setUndoVisible(false)} className="opacity-50 hover:opacity-100 ml-1">✕</button>
+        </div>
+      )}
+
       {showWelcome && (
         <WelcomeScreen
           onContinueAsGuest={() => {

--- a/src/components/AddDestinationModal.jsx
+++ b/src/components/AddDestinationModal.jsx
@@ -2,14 +2,14 @@ import { useState } from 'react'
 import { format, parseISO, startOfDay } from 'date-fns'
 import CitySearch from './CitySearch'
 
-export default function AddDestinationModal({ editing, destinations, onAdd, onUpdate, onClose }) {
+export default function AddDestinationModal({ editing, destinations, onAdd, onUpdate, onClose, lastDeparture = '' }) {
   const [city, setCity] = useState(
     editing
       ? { city: editing.city, country: editing.country, countryCode: editing.countryCode }
       : null
   )
   const [arrival, setArrival] = useState(
-    editing ? format(new Date(editing.arrival), 'yyyy-MM-dd') : ''
+    editing ? format(new Date(editing.arrival), 'yyyy-MM-dd') : (lastDeparture || '')
   )
   const [departure, setDeparture] = useState(
     editing ? format(new Date(editing.departure), 'yyyy-MM-dd') : ''

--- a/src/components/DetailCard.jsx
+++ b/src/components/DetailCard.jsx
@@ -382,8 +382,8 @@ export default function DetailCard({ item, onClose, onEdit }) {
           )}
         </div>
 
-        {/* Footer — hidden on mobile (view-only) */}
-        <div className="hidden sm:block px-5 py-4 border-t border-gray-100 dark:border-gray-800">
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800">
           <button
             data-testid="detail-card-edit"
             onClick={onEdit}

--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { ActivityIcon, BedIcon, TransportIcon } from './Icons'
 
-function DropdownMenu({ label, items, align = 'right' }) {
+function DropdownMenu({ label, items, align = 'right', accent = false }) {
   const [open, setOpen] = useState(false)
   const ref = useRef(null)
 
@@ -25,7 +25,11 @@ function DropdownMenu({ label, items, align = 'right' }) {
     <div className="relative" ref={ref}>
       <button
         onClick={() => setOpen((o) => !o)}
-        className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 text-sm font-medium"
+        className={`w-8 h-8 flex items-center justify-center rounded-lg border transition-colors text-sm font-medium ${
+          accent
+            ? 'bg-sky-500 border-sky-500 text-white hover:bg-sky-600 hover:border-sky-600 dark:bg-sky-600 dark:border-sky-600 dark:hover:bg-sky-500'
+            : 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+        }`}
         aria-expanded={open}
       >
         {label}
@@ -146,13 +150,13 @@ export default function HeaderMenus({
 
   return (
     <div className="flex items-center gap-2 flex-shrink-0">
-      <DropdownMenu label="+" items={addItems} align="right" />
+      <DropdownMenu label="+" items={addItems} align="right" accent />
       <DropdownMenu label="↑" items={shareItems} align="right" />
       {hasData && (
         <button
           onClick={onTravelStats}
           title="Travel Stats"
-          className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400 text-sm"
+          className="w-8 h-8 flex items-center justify-center rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors text-sm"
         >
           📊
         </button>

--- a/src/components/HotelModal.jsx
+++ b/src/components/HotelModal.jsx
@@ -2,13 +2,13 @@ import { useState } from 'react'
 import { format, parseISO, startOfDay, isBefore } from 'date-fns'
 import { BedIcon } from './Icons'
 
-export default function HotelModal({ editing, hotels, onSave, onClose }) {
+export default function HotelModal({ editing, hotels, onSave, onClose, activeDestination = null }) {
   const [name, setName] = useState(editing?.name || '')
   const [checkIn, setCheckIn] = useState(
-    editing ? format(new Date(editing.checkIn), 'yyyy-MM-dd') : ''
+    editing ? format(new Date(editing.checkIn), 'yyyy-MM-dd') : (activeDestination?.arrival || '')
   )
   const [checkOut, setCheckOut] = useState(
-    editing ? format(new Date(editing.checkOut), 'yyyy-MM-dd') : ''
+    editing ? format(new Date(editing.checkOut), 'yyyy-MM-dd') : (activeDestination?.departure || '')
   )
   const [address, setAddress] = useState(editing?.address || '')
   const [confirmationNumber, setConfirmationNumber] = useState(editing?.confirmationNumber || '')

--- a/src/components/InlineDestinationCreator.jsx
+++ b/src/components/InlineDestinationCreator.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { format, addDays, parseISO, startOfDay } from 'date-fns'
+import CitySearch from './CitySearch'
+
+export default function InlineDestinationCreator({ onAdd }) {
+  const [city, setCity] = useState(null)
+  const [arrival, setArrival] = useState('')
+  const [departure, setDeparture] = useState('')
+  const [error, setError] = useState('')
+
+  const handleCitySelect = (c) => {
+    setCity(c)
+    setError('')
+  }
+
+  const handleArrivalChange = (val) => {
+    setArrival(val)
+    setError('')
+    if (val && !departure) {
+      setDeparture(format(addDays(new Date(val), 7), 'yyyy-MM-dd'))
+    }
+  }
+
+  const handleAdd = () => {
+    if (!city?.city) { setError('Pick a city first'); return }
+    if (!arrival) { setError('Set an arrival date'); return }
+    if (!departure) { setError('Set a departure date'); return }
+    if (startOfDay(parseISO(departure)) <= startOfDay(parseISO(arrival))) {
+      setError('Departure must be after arrival')
+      return
+    }
+    onAdd({ city, arrival, departure })
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 sm:py-36 gap-6 px-4">
+      <div className="text-center">
+        <p className="text-base sm:text-lg font-medium text-gray-600 dark:text-gray-300">
+          Where are you going?
+        </p>
+        <p className="text-xs sm:text-sm text-gray-400 dark:text-gray-500 mt-1">
+          Search for your first destination to get started
+        </p>
+      </div>
+
+      <div className="w-full max-w-sm space-y-3">
+        <CitySearch
+          value={city}
+          onChange={handleCitySelect}
+          placeholder="Search for a city…"
+        />
+
+        {city && (
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1.5">Arrival</label>
+              <input
+                type="date"
+                value={arrival}
+                onChange={(e) => handleArrivalChange(e.target.value)}
+                autoFocus
+                className="w-full border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-sky-400 transition-colors bg-white dark:bg-gray-900 dark:text-gray-100"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1.5">Departure</label>
+              <input
+                type="date"
+                value={departure}
+                min={arrival || undefined}
+                onChange={(e) => { setDeparture(e.target.value); setError('') }}
+                className="w-full border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-sky-400 transition-colors bg-white dark:bg-gray-900 dark:text-gray-100"
+              />
+            </div>
+          </div>
+        )}
+
+        {city && arrival && departure && (
+          <button
+            onClick={handleAdd}
+            className="w-full bg-sky-500 hover:bg-sky-600 text-white text-sm font-medium rounded-lg py-2.5 transition-colors"
+          >
+            Start planning {city.city} →
+          </button>
+        )}
+
+        {error && <p className="text-xs text-red-400 text-center">⚠ {error}</p>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -166,6 +166,7 @@ export default function Timeline({
   onEditHotel, onDeleteHotel,
   onEditTransport, onDeleteTransport,
   onClickDest, onClickHotel, onClickActivity, onClickTransport,
+  onDragStart, onDragComplete,
 }) {
   const [zoomIdx, setZoomIdx] = useState(2) // default: index 2 = 36px
   const dayWidth = ZOOM_LEVELS[zoomIdx]
@@ -222,6 +223,7 @@ export default function Timeline({
   const startDrag = (e, dest, mode) => {
     e.preventDefault()
     e.stopPropagation()
+    onDragStart?.()
     dragState.current = {
       id: dest.id,
       mode,
@@ -285,6 +287,7 @@ export default function Timeline({
   // A mouseup with hasMoved=false and mode='move' means the user clicked without
   // dragging — treat it as a selection rather than a completed drag.
   const handleMouseUp = useCallback(() => {
+    const wasDrag = dragState.current?.hasMoved
     if (dragState.current && !dragState.current.hasMoved && dragState.current.mode === 'move') {
       const dest = destinations.find((d) => d.id === dragState.current.id)
       if (dest && onClickDest) onClickDest(dest)
@@ -294,7 +297,8 @@ export default function Timeline({
     setDragMode(null)
     document.body.style.cursor = ''
     document.body.classList.remove('dragging')
-  }, [destinations, onClickDest])
+    if (wasDrag) onDragComplete?.()
+  }, [destinations, onClickDest, onDragComplete])
 
   useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove)
@@ -434,7 +438,20 @@ export default function Timeline({
               <div key={dest.id} style={{ position: 'absolute', left: 0, right: 0, top: rowTop, height: ROW_H }}>
                 {/* No stripe — solid background from container */}
 
-                {/* Live date tooltip while resizing */}
+                {/* Live date tooltip while dragging/resizing */}
+                {isActive && dragMode === 'move' && (
+                  <div style={{
+                    position: 'absolute',
+                    left: blockX + blockW / 2 - 40,
+                    top: 4 - 26,
+                    background: '#111', color: '#fff',
+                    borderRadius: 5, padding: '3px 7px',
+                    fontSize: 10, fontWeight: 500,
+                    whiteSpace: 'nowrap', pointerEvents: 'none', zIndex: 20,
+                  }}>
+                    {format(new Date(dest.arrival), 'MMM d')} → {format(new Date(dest.departure), 'MMM d')}
+                  </div>
+                )}
                 {isActive && dragMode === 'resize-left' && (
                   <div style={{
                     position: 'absolute',


### PR DESCRIPTION
## Summary

- **Travel Stats panel** — year-over-year km traveled, nights away, countries/continents, fun distance comparisons (e.g. "1.3× the Great Wall"), achievement badges, community percentile (auth-gated), and countries-visited flag strip
- **Inline city creator** — replaces the empty-state wizard; just start typing a city to create your first trip, date pickers appear after city is selected, one-click "Start planning →"
- **Undo after timeline drag** — 5-second toast appears after every drag move with a single "Undo" action
- **Date chaining** — Add Destination modal pre-fills arrival from the last destination's departure date
- **Hotel date defaults** — Add Hotel modal pre-fills check-in/check-out from the active destination's dates
- **Mobile edit button** — Edit button in the detail card slide-over is now visible on mobile (was hidden)
- **Mobile FAB** — Fixed `+` button bottom-right on small screens for quick destination add
- **Demo data** — Two seeded trips (Europe + Asia 2025) with exact coordinates to showcase Travel Stats on `/?demo`
- **Misc** — sky-blue accent on `+` header button, blue tint on stats button, `useCloudSync` hook extracted, test suite for `travelStats.js` (haversine, badges, fun comparisons)

## Test plan

- [ ] Visit `/?demo` → Europe Demo loads with two trips visible in the trip switcher
- [ ] Click 📊 → Travel Stats panel opens; shows km, nights, countries for current year; year pills switch between Europe and Asia data
- [ ] Fun comparison carousel cycles; achievement badges show earned/unearned state
- [ ] Open app without `?demo` → inline "Where are you going?" creator shown; select city → dates appear → confirm → first destination added
- [ ] Drag a destination on the timeline → release → undo toast appears → click Undo → position reverts
- [ ] Add Destination → arrival date pre-filled with last destination's departure
- [ ] Add Hotel → check-in/check-out pre-filled from active destination
- [ ] On mobile: FAB visible bottom-right; tap a timeline item → detail card shows Edit button in footer
- [ ] `npm test` — all tests pass

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr