### PR TITLE
feat: date range picker, city facts, circular stats button, UI polish

### DIFF
--- a/src/components/AddDestinationModal.jsx
+++ b/src/components/AddDestinationModal.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { format, parseISO, startOfDay } from 'date-fns'
 import CitySearch from './CitySearch'
+import DateRangePicker from './DateRangePicker'
 
 export default function AddDestinationModal({ editing, destinations, onAdd, onUpdate, onClose, lastDeparture = '' }) {
   const [city, setCity] = useState(
@@ -8,12 +9,16 @@ export default function AddDestinationModal({ editing, destinations, onAdd, onUp
       ? { city: editing.city, country: editing.country, countryCode: editing.countryCode }
       : null
   )
-  const [arrival, setArrival] = useState(
-    editing ? format(new Date(editing.arrival), 'yyyy-MM-dd') : (lastDeparture || '')
-  )
-  const [departure, setDeparture] = useState(
-    editing ? format(new Date(editing.departure), 'yyyy-MM-dd') : ''
-  )
+  const [dateRange, setDateRange] = useState(() => ({
+    from: editing
+      ? startOfDay(new Date(editing.arrival))
+      : lastDeparture
+      ? startOfDay(parseISO(lastDeparture))
+      : null,
+    to: editing ? startOfDay(new Date(editing.departure)) : null,
+  }))
+  const arrival = dateRange.from ? format(dateRange.from, 'yyyy-MM-dd') : ''
+  const departure = dateRange.to ? format(dateRange.to, 'yyyy-MM-dd') : ''
   const [type, setType] = useState(editing?.type || 'vacation')
   const [airline, setAirline] = useState(editing?.airline || '')
   const [flightNumber, setFlightNumber] = useState(editing?.flightNumber || '')
@@ -110,24 +115,13 @@ export default function AddDestinationModal({ editing, destinations, onAdd, onUp
           </div>
 
           {/* Dates */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1.5">Arrival</label>
-              <input
-                type="date"
-                value={arrival}
-                onChange={(e) => { setArrival(e.target.value); setError('') }}
-                className="w-full border border-gray-200 rounded px-3 py-2 text-sm focus:outline-none focus:border-gray-400 transition-colors"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1.5">Departure</label>
-              <input
-                type="date"
-                value={departure}
-
-                onChange={(e) => { setDeparture(e.target.value); setError('') }}
-                className="w-full border border-gray-200 rounded px-3 py-2 text-sm focus:outline-none focus:border-gray-400 transition-colors"
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1.5">Dates</label>
+            <div className="border border-gray-200 dark:border-gray-700 rounded-xl px-3 pt-3 pb-2">
+              <DateRangePicker
+                from={dateRange.from}
+                to={dateRange.to}
+                onChange={(r) => { setDateRange(r); setError('') }}
               />
             </div>
           </div>

--- a/src/components/CitySearch.jsx
+++ b/src/components/CitySearch.jsx
@@ -131,7 +131,7 @@ export default function CitySearch({ value, onChange, placeholder = 'Search city
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           autoComplete="off"
-          className="w-full border border-gray-200 rounded px-3 py-2 text-sm focus:outline-none focus:border-gray-400 transition-colors pr-8"
+          className="w-full border border-gray-200 dark:border-gray-700 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:border-sky-400 dark:focus:border-sky-500 transition-colors pr-8 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-600"
         />
         {loading && (
           <div className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 border border-gray-300 border-t-gray-500 rounded-full animate-spin" />
@@ -139,20 +139,22 @@ export default function CitySearch({ value, onChange, placeholder = 'Search city
       </div>
 
       {open && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full mt-1 bg-white border border-gray-200 rounded shadow-lg z-50 overflow-hidden">
+        <div className="absolute left-0 right-0 top-full mt-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg z-50 overflow-hidden">
           {results.map((r, i) => (
             <button
               key={i}
               type="button"
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => select(r)}
-              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2.5 transition-colors ${
-                i === highlighted ? 'bg-gray-50' : 'hover:bg-gray-50'
-              } ${i < results.length - 1 ? 'border-b border-gray-50' : ''}`}
+              className={`w-full text-left px-3 py-2.5 text-sm flex items-center gap-2.5 transition-colors ${
+                i === highlighted
+                  ? 'bg-gray-50 dark:bg-gray-800'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-800'
+              } ${i < results.length - 1 ? 'border-b border-gray-100 dark:border-gray-800' : ''}`}
             >
               <Flag code={r.countryCode} country={r.country} />
-              <span className="font-medium text-gray-800">{r.city}</span>
-              <span className="text-gray-500 dark:text-gray-400 text-xs">{r.country}</span>
+              <span className="font-medium text-gray-800 dark:text-gray-200">{r.city}</span>
+              <span className="text-gray-400 dark:text-gray-500 text-xs">{r.country}</span>
             </button>
           ))}
         </div>

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import {
+  format, startOfMonth, endOfMonth, startOfWeek, endOfWeek,
+  addDays, addMonths, subMonths, isSameMonth, isSameDay,
+  isAfter, isBefore, isToday, differenceInDays, startOfDay,
+} from 'date-fns'
+
+const WEEKDAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+
+function buildCalendarDays(viewDate) {
+  const monthStart = startOfMonth(viewDate)
+  const monthEnd = endOfMonth(viewDate)
+  const calStart = startOfWeek(monthStart, { weekStartsOn: 1 })
+  const calEnd = endOfWeek(monthEnd, { weekStartsOn: 1 })
+  const days = []
+  let cur = calStart
+  while (!isAfter(cur, calEnd)) {
+    days.push(new Date(cur))
+    cur = addDays(cur, 1)
+  }
+  return days
+}
+
+export default function DateRangePicker({ from, to, onChange, minDate = null }) {
+  const [viewDate, setViewDate] = useState(() => from || new Date())
+  const [hovered, setHovered] = useState(null)
+
+  const picking = from && !to ? 'to' : 'from'
+
+  const isDisabled = (day) => {
+    if (minDate && isBefore(startOfDay(day), startOfDay(minDate))) return true
+    return false
+  }
+
+  const effectiveEnd = to || (picking === 'to' && hovered ? hovered : null)
+
+  const isStart = (day) => from && isSameDay(day, from)
+  const isEnd = (day) => to && isSameDay(day, to)
+  const isInRange = (day) => {
+    if (!from || !effectiveEnd) return false
+    if (isSameDay(day, from) || isSameDay(day, effectiveEnd)) return false
+    const [lo, hi] = isAfter(effectiveEnd, from)
+      ? [from, effectiveEnd]
+      : [effectiveEnd, from]
+    return isAfter(day, lo) && isBefore(day, hi)
+  }
+
+  const showRangeStrip = (day) => {
+    if (!from || !effectiveEnd) return null
+    const [lo, hi] = isAfter(effectiveEnd, from)
+      ? [from, effectiveEnd]
+      : [effectiveEnd, from]
+    if (isStart(day) && !isSameDay(from, effectiveEnd) && isAfter(effectiveEnd, from)) return 'right'
+    if (isEnd(day) && !isSameDay(from, to || hovered)) return 'left'
+    if (isInRange(day)) return 'full'
+    return null
+  }
+
+  const handleDayClick = (day) => {
+    if (isDisabled(day)) return
+    if (picking === 'from' || !from) {
+      onChange({ from: day, to: null })
+      setHovered(null)
+    } else {
+      if (isBefore(day, from) && !isSameDay(day, from)) {
+        onChange({ from: day, to: null })
+      } else {
+        onChange({ from, to: day })
+      }
+      setHovered(null)
+    }
+  }
+
+  const days = buildCalendarDays(viewDate)
+  const nights = from && to ? differenceInDays(to, from) : null
+
+  return (
+    <div className="select-none w-full">
+      {/* Month navigation */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          type="button"
+          onClick={() => setViewDate(subMonths(viewDate, 1))}
+          className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-400 transition-colors text-lg leading-none"
+        >‹</button>
+        <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          {format(viewDate, 'MMMM yyyy')}
+        </span>
+        <button
+          type="button"
+          onClick={() => setViewDate(addMonths(viewDate, 1))}
+          className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-400 transition-colors text-lg leading-none"
+        >›</button>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 mb-1">
+        {WEEKDAYS.map((d) => (
+          <div key={d} className="flex items-center justify-center h-7 text-xs font-medium text-gray-400 dark:text-gray-600">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7">
+        {days.map((day, i) => {
+          const disabled = isDisabled(day)
+          const start = isStart(day)
+          const end = isEnd(day)
+          const strip = showRangeStrip(day)
+          const inMonth = isSameMonth(day, viewDate)
+          const today = isToday(day)
+
+          let dayClass = 'relative z-10 w-8 h-8 flex items-center justify-center text-xs transition-colors rounded-full'
+          if (disabled) {
+            dayClass += ' text-gray-300 dark:text-gray-700 cursor-default'
+          } else if (start || end) {
+            dayClass += ' bg-sky-500 text-white font-semibold cursor-pointer'
+          } else if (isInRange(day)) {
+            dayClass += ' text-sky-700 dark:text-sky-300 cursor-pointer hover:bg-sky-200 dark:hover:bg-sky-800'
+          } else if (!inMonth) {
+            dayClass += ' text-gray-300 dark:text-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800'
+          } else if (today) {
+            dayClass += ' text-sky-500 dark:text-sky-400 font-semibold cursor-pointer hover:bg-sky-50 dark:hover:bg-sky-900/30'
+          } else {
+            dayClass += ' text-gray-700 dark:text-gray-300 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800'
+          }
+
+          return (
+            <div
+              key={i}
+              className="relative flex items-center justify-center h-8"
+              onMouseEnter={() => !disabled && picking === 'to' && from && setHovered(day)}
+              onMouseLeave={() => setHovered(null)}
+            >
+              {/* Range strip background */}
+              {strip === 'full' && (
+                <div className="absolute inset-0 bg-sky-100 dark:bg-sky-900/25" />
+              )}
+              {strip === 'right' && (
+                <div className="absolute top-0 bottom-0 left-1/2 right-0 bg-sky-100 dark:bg-sky-900/25" />
+              )}
+              {strip === 'left' && (
+                <div className="absolute top-0 bottom-0 left-0 right-1/2 bg-sky-100 dark:bg-sky-900/25" />
+              )}
+              <button
+                type="button"
+                onClick={() => handleDayClick(day)}
+                disabled={disabled}
+                className={dayClass}
+              >
+                {format(day, 'd')}
+              </button>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Status hint */}
+      <p className="text-xs text-center mt-2.5 h-4 text-gray-400 dark:text-gray-600">
+        {!from
+          ? 'Tap arrival date'
+          : !to
+          ? 'Now tap departure date'
+          : `${nights} night${nights !== 1 ? 's' : ''}`}
+      </p>
+    </div>
+  )
+}

--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -156,12 +156,12 @@ export default function HeaderMenus({
         <button
           onClick={onTravelStats}
           title="Travel Stats"
-          className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          className="w-9 h-9 flex items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-600 text-white hover:from-blue-400 hover:to-violet-500 active:scale-95 transition-all shadow-sm"
         >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <rect x="0" y="7" width="3" height="7" rx="1" fill="currentColor" />
-            <rect x="5.5" y="3" width="3" height="11" rx="1" fill="currentColor" />
-            <rect x="11" y="0" width="3" height="14" rx="1" fill="currentColor" />
+          <svg width="15" height="15" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            <rect x="0" y="7" width="3" height="7" rx="1" fill="white" />
+            <rect x="5.5" y="3" width="3" height="11" rx="1" fill="white" />
+            <rect x="11" y="0" width="3" height="14" rx="1" fill="white" />
           </svg>
         </button>
       )}

--- a/src/components/InlineDestinationCreator.jsx
+++ b/src/components/InlineDestinationCreator.jsx
@@ -1,45 +1,59 @@
-import { useState } from 'react'
-import { format, addDays, parseISO, startOfDay } from 'date-fns'
+import { useState, useEffect } from 'react'
+import { format } from 'date-fns'
 import CitySearch from './CitySearch'
+import DateRangePicker from './DateRangePicker'
+
+async function fetchCityFact(cityName) {
+  try {
+    const res = await fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(cityName)}`,
+      { headers: { Accept: 'application/json' } }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    return data.description || null
+  } catch {
+    return null
+  }
+}
 
 export default function InlineDestinationCreator({ onAdd }) {
   const [city, setCity] = useState(null)
-  const [arrival, setArrival] = useState('')
-  const [departure, setDeparture] = useState('')
+  const [range, setRange] = useState({ from: null, to: null })
+  const [fact, setFact] = useState(null)
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!city) { setFact(null); return }
+    setFact(null)
+    fetchCityFact(city.city).then(setFact)
+  }, [city])
 
   const handleCitySelect = (c) => {
     setCity(c)
+    setRange({ from: null, to: null })
     setError('')
-  }
-
-  const handleArrivalChange = (val) => {
-    setArrival(val)
-    setError('')
-    if (val && !departure) {
-      setDeparture(format(addDays(new Date(val), 7), 'yyyy-MM-dd'))
-    }
   }
 
   const handleAdd = () => {
     if (!city?.city) { setError('Pick a city first'); return }
-    if (!arrival) { setError('Set an arrival date'); return }
-    if (!departure) { setError('Set a departure date'); return }
-    if (startOfDay(parseISO(departure)) <= startOfDay(parseISO(arrival))) {
-      setError('Departure must be after arrival')
-      return
-    }
-    onAdd({ city, arrival, departure })
+    if (!range.from) { setError('Pick an arrival date'); return }
+    if (!range.to) { setError('Pick a departure date'); return }
+    onAdd({
+      city,
+      arrival: format(range.from, 'yyyy-MM-dd'),
+      departure: format(range.to, 'yyyy-MM-dd'),
+    })
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-24 sm:py-36 gap-6 px-4">
-      <div className="text-center">
-        <p className="text-base sm:text-lg font-medium text-gray-600 dark:text-gray-300">
-          Where are you going?
-        </p>
-        <p className="text-xs sm:text-sm text-gray-400 dark:text-gray-500 mt-1">
-          Search for your first destination to get started
+    <div className="flex flex-col items-center justify-center py-12 sm:py-24 gap-8 px-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white tracking-tight">
+          Where to next?
+        </h1>
+        <p className="text-sm text-gray-400 dark:text-gray-500">
+          Search a city to start planning your trip
         </p>
       </div>
 
@@ -50,41 +64,40 @@ export default function InlineDestinationCreator({ onAdd }) {
           placeholder="Search for a city…"
         />
 
-        {city && (
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1.5">Arrival</label>
-              <input
-                type="date"
-                value={arrival}
-                onChange={(e) => handleArrivalChange(e.target.value)}
-                autoFocus
-                className="w-full border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-sky-400 transition-colors bg-white dark:bg-gray-900 dark:text-gray-100"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1.5">Departure</label>
-              <input
-                type="date"
-                value={departure}
-                min={arrival || undefined}
-                onChange={(e) => { setDeparture(e.target.value); setError('') }}
-                className="w-full border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-sky-400 transition-colors bg-white dark:bg-gray-900 dark:text-gray-100"
-              />
-            </div>
+        {/* Did you know? */}
+        {city && fact && (
+          <div className="flex gap-2.5 items-start bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800/30 rounded-2xl px-3.5 py-2.5 animate-fade-in">
+            <span className="text-base leading-snug mt-0.5 flex-shrink-0">💡</span>
+            <p className="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+              <span className="font-semibold">{city.city}</span> — {fact}
+            </p>
           </div>
         )}
 
-        {city && arrival && departure && (
+        {/* Date range picker */}
+        {city && (
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl px-4 pt-4 pb-3 shadow-sm">
+            <DateRangePicker
+              from={range.from}
+              to={range.to}
+              onChange={setRange}
+              minDate={new Date()}
+            />
+          </div>
+        )}
+
+        {city && range.from && range.to && (
           <button
             onClick={handleAdd}
-            className="w-full bg-sky-500 hover:bg-sky-600 text-white text-sm font-medium rounded-lg py-2.5 transition-colors"
+            className="w-full bg-sky-500 hover:bg-sky-600 active:scale-[0.98] text-white text-sm font-semibold rounded-full py-3 transition-all shadow-sm shadow-sky-200 dark:shadow-none"
           >
             Start planning {city.city} →
           </button>
         )}
 
-        {error && <p className="text-xs text-red-400 text-center">⚠ {error}</p>}
+        {error && (
+          <p className="text-xs text-red-400 text-center">⚠ {error}</p>
+        )}
       </div>
     </div>
   )

--- a/src/components/__tests__/AddDestinationModal.test.jsx
+++ b/src/components/__tests__/AddDestinationModal.test.jsx
@@ -23,6 +23,30 @@ vi.mock('../CitySearch', () => ({
   Flag: ({ code }) => <span data-testid="flag">{code}</span>,
 }))
 
+// Stub DateRangePicker with two plain date inputs for easy test control
+vi.mock('../DateRangePicker', () => ({
+  default: ({ from, to, onChange }) => (
+    <div>
+      <input
+        type="date"
+        data-testid="date-from"
+        value={from ? from.toISOString().slice(0, 10) : ''}
+        onChange={(e) =>
+          onChange({ from: e.target.value ? new Date(e.target.value + 'T00:00:00') : null, to })
+        }
+      />
+      <input
+        type="date"
+        data-testid="date-to"
+        value={to ? to.toISOString().slice(0, 10) : ''}
+        onChange={(e) =>
+          onChange({ from, to: e.target.value ? new Date(e.target.value + 'T00:00:00') : null })
+        }
+      />
+    </div>
+  ),
+}))
+
 const defaultProps = {
   editing: null,
   destinations: [],
@@ -41,10 +65,9 @@ async function fillCity(user, value = 'Paris') {
   await user.type(input, value)
 }
 
-async function fillDates(user, arrival = '2025-08-01', departure = '2025-08-07') {
-  const [arrInput, depInput] = screen.getAllByDisplayValue('')
-  fireEvent.change(arrInput, { target: { value: arrival } })
-  fireEvent.change(depInput, { target: { value: departure } })
+function fillDates(arrival = '2025-08-01', departure = '2025-08-07') {
+  fireEvent.change(screen.getByTestId('date-from'), { target: { value: arrival } })
+  fireEvent.change(screen.getByTestId('date-to'), { target: { value: departure } })
 }
 
 describe('AddDestinationModal', () => {
@@ -94,8 +117,7 @@ describe('AddDestinationModal', () => {
   it('shows error when departure date is missing', async () => {
     renderModal()
     await fillCity(user)
-    const [arrInput] = screen.getAllByDisplayValue('')
-    fireEvent.change(arrInput, { target: { value: '2025-08-01' } })
+    fireEvent.change(screen.getByTestId('date-from'), { target: { value: '2025-08-01' } })
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(screen.getByText(/please set a departure date/i)).toBeInTheDocument()
@@ -105,9 +127,7 @@ describe('AddDestinationModal', () => {
   it('shows error when departure is before arrival', async () => {
     renderModal()
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-07' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-01' } })
+    fillDates('2025-08-07', '2025-08-01')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(screen.getByText(/departure cannot be before arrival/i)).toBeInTheDocument()
@@ -122,9 +142,7 @@ describe('AddDestinationModal', () => {
     }
     renderModal({ destinations: [existing] })
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-01' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-08' } })
+    fillDates('2025-08-01', '2025-08-08')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(screen.getByText(/overlap/i)).toBeInTheDocument()
@@ -139,10 +157,8 @@ describe('AddDestinationModal', () => {
     }
     renderModal({ destinations: [existing] })
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
     // New destination starts exactly when existing ends — should be allowed
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-05' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-10' } })
+    fillDates('2025-08-05', '2025-08-10')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(screen.queryByText(/overlap/i)).not.toBeInTheDocument()
@@ -153,9 +169,7 @@ describe('AddDestinationModal', () => {
   it('calls onAdd with correct data when form is valid', async () => {
     renderModal()
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-01' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-07' } })
+    fillDates('2025-08-01', '2025-08-07')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(defaultProps.onAdd).toHaveBeenCalledTimes(1)
@@ -177,9 +191,7 @@ describe('AddDestinationModal', () => {
     renderModal()
     await user.click(screen.getByText('Business'))
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-01' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-07' } })
+    fillDates('2025-08-01', '2025-08-07')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(defaultProps.onAdd).toHaveBeenCalledTimes(1)
@@ -210,9 +222,7 @@ describe('AddDestinationModal', () => {
   it('includes budget in payload when provided', async () => {
     renderModal()
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-01' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-07' } })
+    fillDates('2025-08-01', '2025-08-07')
     const budgetInput = document.querySelector('input[type="number"]')
     fireEvent.change(budgetInput, { target: { value: '500' } })
     fireEvent.submit(document.querySelector('form'))
@@ -225,9 +235,7 @@ describe('AddDestinationModal', () => {
   it('omits budget from payload when empty', async () => {
     renderModal()
     await fillCity(user)
-    const dateInputs = document.querySelectorAll('input[type="date"]')
-    fireEvent.change(dateInputs[0], { target: { value: '2025-08-01' } })
-    fireEvent.change(dateInputs[1], { target: { value: '2025-08-07' } })
+    fillDates('2025-08-01', '2025-08-07')
     fireEvent.submit(document.querySelector('form'))
     await waitFor(() => {
       expect(defaultProps.onAdd).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

- **Date range picker** — replaces the two separate date inputs in both the empty-state creator and the Add Destination modal. Single calendar, tap arrival first, then departure. Range highlighted in sky-blue with a strip between the two dates. Hover preview shows the range before confirming. Disabled past dates. Night count shown as status hint.
- **"Did you know?"** — after selecting a city in the empty-state creator, fetches the Wikipedia summary and shows a short amber card with a fun fact (e.g. "Paris — capital and most populous city of France")
- **Stats button** — circular gradient (blue → violet) with white SVG bar chart icon, matching the reference image
- **"Where to next?"** heading — large bold h1, replaces the small muted text
- **CitySearch dark mode** — full dark mode on input and dropdown; rounded-xl input; improved contrast
- **Rounded-full primary button** — confirm button on empty-state creator

## Test plan

- [ ] Open app fresh (no ?demo) → see bold "Where to next?" heading
- [ ] Type a city → select it → amber "Did you know?" card appears
- [ ] Calendar appears → tap a date → tap another date → range highlights, nights count shown
- [ ] Tap arrival date again while picking departure → resets range cleanly
- [ ] "Start planning →" button appears → click → trip created
- [ ] Open Add Destination modal → calendar shown for dates → works same way
- [ ] Stats button: circular blue/violet gradient, white bars icon
- [ ] Dark mode: CitySearch input and dropdown render correctly
- [ ] `npm test` → 157 tests pass

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr)_