### PR TITLE
feat: date range picker in QuickStart, round buttons, neutral stats button

### DIFF
--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -25,7 +25,7 @@ function DropdownMenu({ label, items, align = 'right', accent = false }) {
     <div className="relative" ref={ref}>
       <button
         onClick={() => setOpen((o) => !o)}
-        className={`w-8 h-8 flex items-center justify-center rounded-xl border transition-colors text-sm font-medium ${
+        className={`w-8 h-8 flex items-center justify-center rounded-full border transition-colors text-sm font-medium ${
           accent
             ? 'bg-sky-500 border-sky-500 text-white hover:bg-sky-600 hover:border-sky-600 dark:bg-sky-600 dark:border-sky-600 dark:hover:bg-sky-500'
             : 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
@@ -163,12 +163,12 @@ export default function HeaderMenus({
         <button
           onClick={onTravelStats}
           title="Travel Stats"
-          className="w-9 h-9 flex items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-600 text-white hover:from-blue-400 hover:to-violet-500 active:scale-95 transition-all shadow-sm"
+          className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
         >
-          <svg width="15" height="15" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <rect x="0" y="7" width="3" height="7" rx="1" fill="white" />
-            <rect x="5.5" y="3" width="3" height="11" rx="1" fill="white" />
-            <rect x="11" y="0" width="3" height="14" rx="1" fill="white" />
+          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            <rect x="0" y="7" width="3" height="7" rx="1" fill="currentColor" />
+            <rect x="5.5" y="3" width="3" height="11" rx="1" fill="currentColor" />
+            <rect x="11" y="0" width="3" height="14" rx="1" fill="currentColor" />
           </svg>
         </button>
       )}

--- a/src/components/quickstart/StepAccommodation.jsx
+++ b/src/components/quickstart/StepAccommodation.jsx
@@ -1,3 +1,6 @@
+import { startOfDay, format } from 'date-fns'
+import DateRangePicker from '../DateRangePicker'
+
 const inputCls = 'w-full bg-[#2E2E33] border border-[#3A3A40] rounded-xl px-3 py-2.5 text-sm text-[#F5F5F5] focus:outline-none focus:border-[#5A5A60] transition-colors'
 
 function YesNo({ value, onChange }) {
@@ -39,7 +42,7 @@ export default function StepAccommodation({ hasAccommodation, accommodations, on
       <YesNo value={hasAccommodation} onChange={onHasAccommodationChange} />
 
       {hasAccommodation && (
-        <div className="flex flex-col gap-3 max-h-56 overflow-y-auto pr-1">
+        <div className="flex flex-col gap-3 max-h-[28rem] overflow-y-auto pr-1">
           {accommodations.map((hotel, i) => (
             <div key={i} className="bg-[#242428] rounded-xl p-4 flex flex-col gap-3">
               <input
@@ -49,14 +52,16 @@ export default function StepAccommodation({ hasAccommodation, accommodations, on
                 data-testid="hotel-name-input"
                 className={inputCls}
               />
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <label className="block text-xs text-[#7A7A80] mb-1">Check-in</label>
-                  <input type="date" value={hotel.checkIn} onChange={(e) => update(i, { checkIn: e.target.value })} className={inputCls} style={{ colorScheme: 'dark' }} />
-                </div>
-                <div>
-                  <label className="block text-xs text-[#7A7A80] mb-1">Check-out</label>
-                  <input type="date" value={hotel.checkOut} min={hotel.checkIn || undefined} onChange={(e) => update(i, { checkOut: e.target.value })} className={inputCls} style={{ colorScheme: 'dark' }} />
+              <div className="dark">
+                <div className="border border-[#3A3A40] rounded-xl px-3 pt-3 pb-2">
+                  <DateRangePicker
+                    from={hotel.checkIn ? startOfDay(new Date(hotel.checkIn + 'T00:00:00')) : null}
+                    to={hotel.checkOut ? startOfDay(new Date(hotel.checkOut + 'T00:00:00')) : null}
+                    onChange={(r) => update(i, {
+                      checkIn: r.from ? format(r.from, 'yyyy-MM-dd') : '',
+                      checkOut: r.to ? format(r.to, 'yyyy-MM-dd') : '',
+                    })}
+                  />
                 </div>
               </div>
               <input value={hotel.address} onChange={(e) => update(i, { address: e.target.value })} placeholder="Address (optional)" className={inputCls} />

--- a/src/components/quickstart/StepDestinations.jsx
+++ b/src/components/quickstart/StepDestinations.jsx
@@ -1,8 +1,8 @@
+import { startOfDay, format } from 'date-fns'
 import CitySearch from '../CitySearch'
+import DateRangePicker from '../DateRangePicker'
 
 const emptyDest = () => ({ city: '', country: '', countryCode: '', arrival: '', departure: '' })
-
-const inputCls = 'w-full bg-[#2E2E33] border border-[#3A3A40] rounded-xl px-3 py-2.5 text-sm text-[#F5F5F5] focus:outline-none focus:border-[#5A5A60] transition-colors'
 
 export default function StepDestinations({ destinations, onChange }) {
   const update = (i, patch) =>
@@ -17,7 +17,7 @@ export default function StepDestinations({ destinations, onChange }) {
         <p className="text-sm text-[#7A7A80]">Add all your stops — you can edit dates later.</p>
       </div>
 
-      <div className="flex flex-col gap-4 max-h-72 overflow-y-auto pr-1">
+      <div className="flex flex-col gap-4 max-h-[28rem] overflow-y-auto pr-1">
         {destinations.map((dest, i) => (
           <div key={i} className="bg-[#242428] rounded-xl p-4 flex flex-col gap-3">
             <div className="flex items-center justify-between">
@@ -36,26 +36,15 @@ export default function StepDestinations({ destinations, onChange }) {
             <div className="qs-city-search">
               <CitySearch value={dest} onChange={(c) => update(i, c)} placeholder="Search city…" />
             </div>
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <label className="block text-xs text-[#7A7A80] mb-1">Arrival</label>
-                <input
-                  type="date"
-                  value={dest.arrival}
-                  onChange={(e) => update(i, { arrival: e.target.value })}
-                  className={inputCls}
-                  style={{ colorScheme: 'dark' }}
-                />
-              </div>
-              <div>
-                <label className="block text-xs text-[#7A7A80] mb-1">Departure</label>
-                <input
-                  type="date"
-                  value={dest.departure}
-                  min={dest.arrival || undefined}
-                  onChange={(e) => update(i, { departure: e.target.value })}
-                  className={inputCls}
-                  style={{ colorScheme: 'dark' }}
+            <div className="dark">
+              <div className="border border-[#3A3A40] rounded-xl px-3 pt-3 pb-2">
+                <DateRangePicker
+                  from={dest.arrival ? startOfDay(new Date(dest.arrival + 'T00:00:00')) : null}
+                  to={dest.departure ? startOfDay(new Date(dest.departure + 'T00:00:00')) : null}
+                  onChange={(r) => update(i, {
+                    arrival: r.from ? format(r.from, 'yyyy-MM-dd') : '',
+                    departure: r.to ? format(r.to, 'yyyy-MM-dd') : '',
+                  })}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **Consistent date picker**: QuickStart "New Trip" flow (StepDestinations + StepAccommodation) now uses the same tap-start/tap-end `DateRangePicker` calendar as AddDestinationModal and HotelModal. No more native browser date inputs anywhere.
- **Round buttons everywhere**: all three header buttons (`+`, `↑`, stats) use `rounded-full` so they appear as circles.
- **Stats button de-accented**: removed the blue-violet gradient; stats button now matches the neutral border style of the `↑` share button. Only the `+` add button keeps the sky-blue accent fill.

## Test plan

- [ ] All 157 tests pass
- [ ] New Trip → type a name → Next → pick Solo/Group → calendar appears for destination dates (tap arrival, tap departure, range highlights)
- [ ] New Trip → accommodation step → Yes → calendar appears for hotel check-in/check-out
- [ ] Header shows three circular buttons: `+` (sky blue filled), `↑` (gray border), stats bars (gray border)

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr)_