### PR TITLE
fix: WhatsApp share sends app link, stats button rounded-full

### DIFF
--- a/src/components/HeaderMenus.jsx
+++ b/src/components/HeaderMenus.jsx
@@ -171,7 +171,7 @@ export default function HeaderMenus({
           title="Travel Stats"
           className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
         >
-          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
             <rect x="0" y="7" width="3" height="7" rx="1" fill="currentColor" />
             <rect x="5.5" y="3" width="3" height="11" rx="1" fill="currentColor" />
             <rect x="11" y="0" width="3" height="14" rx="1" fill="currentColor" />


### PR DESCRIPTION
## Summary
- WhatsApp share now sends the live app URL alongside the trip summary text instead of a bare message
- Stats button in desktop header uses `rounded-full` (consistent with other header buttons) and slightly larger SVG icon (14px)

## Test plan
- [ ] Tap "Share via WhatsApp" → message includes the app link
- [ ] Stats button appears as a circle matching the `+` and `↑` buttons in the header
- [ ] All 157 tests pass (`npm test`)

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr)_