### PR TITLE
feat: mobile UX P2 — section nav, onboarding tooltip, SW crash fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,14 @@
       window.addEventListener('unhandledrejection', function(e) {
         showCrash('Unhandled promise rejection:\n' + (e.reason && (e.reason.stack || e.reason.toString ? e.reason.toString() : '') || String(e.reason)));
       });
+      // When a new service worker takes control, reload so fresh JS chunks are served.
+      // Without this, autoUpdate can serve new HTML pointing to chunk hashes that
+      // aren't in the old cached bundle, causing "Script error. (:0)" on iOS Safari.
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.addEventListener('controllerchange', function() {
+          window.location.reload();
+        });
+      }
     </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -542,8 +542,26 @@ export default function App() {
           <InlineDestinationCreator onAdd={handleInlineAdd} />
         ) : (
           <>
+            {/* Mobile section-jump nav */}
+            <div className="sm:hidden -mx-4 px-3 mb-5 flex gap-2 overflow-x-auto scrollbar-hide">
+              {[
+                { label: 'Timeline', id: 'sec-timeline' },
+                { label: 'Map', id: 'sec-map' },
+                { label: 'Hotels', id: 'sec-hotels', hide: hotels.length === 0 },
+                { label: 'Summary', id: 'sec-summary' },
+              ].filter(s => !s.hide).map(({ label, id }) => (
+                <button
+                  key={id}
+                  onClick={() => document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                  className="flex-shrink-0 text-xs font-medium px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
             {/* Timeline */}
-            <section className="mb-12 -mx-4 sm:mx-0 px-4 sm:px-0">
+            <section id="sec-timeline" className="mb-12 -mx-4 sm:mx-0 px-4 sm:px-0">
               <Timeline
                 destinations={destinations}
                 activities={activities}
@@ -575,7 +593,7 @@ export default function App() {
             <WeatherWidget destinations={destinations} />
 
             {/* Map */}
-            <MapView destinations={destinations} dark={dark} />
+            <div id="sec-map"><MapView destinations={destinations} dark={dark} /></div>
 
             {/* Destinations + Packing list — side by side with drag-resize handle */}
             <div ref={twoColRef} className="flex flex-col lg:flex-row items-start mb-8">
@@ -682,7 +700,7 @@ export default function App() {
 
             {/* Hotel list */}
             {hotels.length > 0 && (
-              <section className="mb-8">
+              <section id="sec-hotels" className="mb-8">
                 <div className="flex items-center justify-between mb-3 cursor-pointer select-none" onClick={() => setHotelsOpen(o => !o)}>
                   <h2 className="text-xs font-medium text-gray-500 dark:text-gray-500 uppercase tracking-wider flex items-center gap-2">
                     <BedIcon size={11} color="#9ca3af" /> Hotels
@@ -752,7 +770,7 @@ export default function App() {
             )}
 
             {/* Summary dashboard */}
-            <SummaryDashboard destinations={destinations} hotels={hotels} activities={activities} transports={transports} currency={tripCurrency} onCurrencyChange={setCurrency} />
+            <div id="sec-summary"><SummaryDashboard destinations={destinations} hotels={hotels} activities={activities} transports={transports} currency={tripCurrency} onCurrencyChange={setCurrency} /></div>
           </>
         )}
       </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -470,6 +470,13 @@ export default function App() {
                 <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
               </svg>
             </button>
+            {/* Auth button — mobile only (desktop version is in the right section) */}
+            <div className="sm:hidden flex-shrink-0">
+              <AuthButton user={user} onShowWelcome={() => {
+                localStorage.removeItem(GUEST_MODE_KEY)
+                setGuestMode(false)
+              }} />
+            </div>
             <h1 className="text-base font-medium text-gray-900 dark:text-gray-100 flex-shrink-0">Wayfar</h1>
             {/* Active trip name */}
             {activeTrip && (

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -207,6 +207,7 @@ export default function Timeline({
   const [hoverId, setHoverId] = useState(null)
   const [hoverHotelId, setHoverHotelId] = useState(null)
   const [hoverTransportId, setHoverTransportId] = useState(null)
+  const [showHint, setShowHint] = useState(() => !localStorage.getItem('wayfar-timeline-hint-seen'))
 
   const { startDate, endDate } = computeRange(destinations, hotels, transports)
   const totalDays = differenceInDays(endDate, startDate) + 1
@@ -215,6 +216,16 @@ export default function Timeline({
   const todayOffset = differenceInDays(today, startDate)
 
   const activityMap = useMemo(() => groupActivities(activities), [activities])
+
+  // Dismiss onboarding hint after 6 seconds
+  useEffect(() => {
+    if (!showHint) return
+    const t = setTimeout(() => {
+      setShowHint(false)
+      localStorage.setItem('wayfar-timeline-hint-seen', '1')
+    }, 6000)
+    return () => clearTimeout(t)
+  }, [showHint])
 
   // Scroll to show today on mount
   const scrollToToday = () => {
@@ -329,7 +340,16 @@ export default function Timeline({
   const canvasH = HEADER_H + destTotalH + hotelTotalH + transportTotalH + 8
 
   return (
-    <div>
+    <div className="relative">
+      {/* First-time onboarding hint */}
+      {showHint && destinations.length > 0 && (
+        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 z-20 mb-2 pointer-events-none">
+          <div className="flex items-center gap-2 bg-gray-900/90 dark:bg-gray-100/90 text-white dark:text-gray-900 text-xs rounded-full px-4 py-2 shadow-lg animate-pulse-once whitespace-nowrap">
+            <span>✦</span>
+            <span>Drag bars to reschedule · tap to view details</span>
+          </div>
+        </div>
+      )}
       {/* Zoom controls */}
       <div className="flex items-center gap-1 mb-2 justify-end">
         <button


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **iOS "Script error. (:0)" crash fix** — `index.html` now reloads the page when the service worker takes control, preventing stale JS chunk hashes from crashing the app after a PWA update
- **Mobile section-jump nav** — horizontal chip strip (Timeline · Map · Hotels · Summary) appears on mobile only, smooth-scrolls to each section; hidden on desktop
- **AuthButton on mobile header** — sign-in button was missing from screens < 640px; added alongside the hamburger
- **First-time onboarding tooltip** — "Drag bars to reschedule · tap to view details" appears once above the timeline, auto-dismisses after 6 s, remembered via `localStorage`
- **WhatsApp share + stats button polish** — share sends app link, stats button uses clean SVG bar-chart icon

## Test plan

- [ ] All 157 Vitest tests pass (`npm test`)
- [ ] On mobile (375px): section chips appear at top of trip content, tapping each scrolls to correct section
- [ ] First visit with timeline data: tooltip appears, fades out after ~6 s; second visit: no tooltip
- [ ] iOS Safari PWA: after SW update, page reloads cleanly instead of crashing with "Script error. (:0)"
- [ ] Mobile header shows AuthButton (sign-in/user avatar) next to hamburger

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr)_