### PR TITLE
feat(ios): hotel/activity/transport modals + full TravelStats screen

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { View, Text, ScrollView, Pressable, useColorScheme, ActivityIndicator } from 'react-native'
+import { View, Text, ScrollView, Pressable, useColorScheme, ActivityIndicator, Modal, Alert } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { useTrips } from '../../src/hooks/useTrips'
@@ -14,17 +14,25 @@ type SelectedItem =
   | { kind: 'transport'; data: Transport }
   | null
 
+const ADD_OPTIONS = [
+  { label: '📍 Destination', route: '/destination-modal' as const },
+  { label: '🏨 Hotel', route: '/hotel-modal' as const },
+  { label: '🎯 Activity', route: '/activity-modal' as const },
+  { label: '✈️ Transport', route: '/transport-modal' as const },
+] as const
+
 export default function TripScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const colorScheme = useColorScheme()
 
   const {
     trips, activeTripId, setActiveTripId, activeTrip, loaded,
     loadDemoData,
+    deleteDestination, deleteHotel, deleteActivity, deleteTransport,
   } = useTrips()
 
   const [selectedItem, setSelectedItem] = useState<SelectedItem>(null)
+  const [showAddMenu, setShowAddMenu] = useState(false)
 
   const destinations = activeTrip?.destinations || []
   const hotels = activeTrip?.hotels || []
@@ -36,6 +44,50 @@ export default function TripScreen() {
       <View className="flex-1 items-center justify-center bg-gray-50 dark:bg-gray-950">
         <ActivityIndicator size="large" color="#0ea5e9" />
       </View>
+    )
+  }
+
+  const handleEdit = () => {
+    const item = selectedItem
+    setSelectedItem(null)
+    if (!item) return
+    if (item.kind === 'destination') {
+      router.push({ pathname: '/destination-modal', params: { editing: JSON.stringify(item.data) } })
+    } else if (item.kind === 'hotel') {
+      router.push({ pathname: '/hotel-modal', params: { editing: JSON.stringify(item.data) } })
+    } else if (item.kind === 'activity') {
+      router.push({ pathname: '/activity-modal', params: { editing: JSON.stringify(item.data) } })
+    } else if (item.kind === 'transport') {
+      router.push({ pathname: '/transport-modal', params: { editing: JSON.stringify(item.data) } })
+    }
+  }
+
+  const handleDelete = () => {
+    const item = selectedItem
+    if (!item) return
+    const label =
+      item.kind === 'destination' ? item.data.city :
+      item.kind === 'hotel' ? item.data.name :
+      item.kind === 'activity' ? item.data.name :
+      `${item.data.fromCity} → ${item.data.toCity}`
+
+    Alert.alert(
+      'Delete',
+      `Remove "${label}"?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            setSelectedItem(null)
+            if (item.kind === 'destination') deleteDestination(item.data.id)
+            else if (item.kind === 'hotel') deleteHotel(item.data.id)
+            else if (item.kind === 'activity') deleteActivity(item.data.id)
+            else if (item.kind === 'transport') deleteTransport(item.data.id)
+          },
+        },
+      ]
     )
   }
 
@@ -53,7 +105,7 @@ export default function TripScreen() {
             {activeTrip?.name || 'My Trip'}
           </Text>
           <Pressable
-            onPress={() => router.push('/destination-modal')}
+            onPress={() => setShowAddMenu(true)}
             className="w-9 h-9 bg-sky-500 rounded-full items-center justify-center"
           >
             <Text className="text-white text-2xl font-light" style={{ lineHeight: 28 }}>+</Text>
@@ -133,16 +185,61 @@ export default function TripScreen() {
         </ScrollView>
       )}
 
+      {/* ── Detail Card ── */}
       <DetailCard
         item={selectedItem}
         onClose={() => setSelectedItem(null)}
-        onEdit={() => {
-          setSelectedItem(null)
-          if (selectedItem?.kind === 'destination') {
-            router.push({ pathname: '/destination-modal', params: { editing: JSON.stringify(selectedItem.data) } })
-          }
-        }}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
       />
+
+      {/* ── Add Menu ── */}
+      <Modal
+        visible={showAddMenu}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowAddMenu(false)}
+      >
+        <Pressable
+          className="flex-1 bg-black/40 justify-end"
+          onPress={() => setShowAddMenu(false)}
+        >
+          <Pressable
+            className="bg-white dark:bg-gray-900 rounded-t-3xl px-4 pt-4"
+            style={{ paddingBottom: insets.bottom + 16 }}
+            onPress={() => {}}
+          >
+            {/* Handle */}
+            <View className="items-center mb-4">
+              <View className="w-8 h-1 rounded-full bg-gray-200 dark:bg-gray-700" />
+            </View>
+
+            <Text className="text-base font-semibold text-gray-900 dark:text-white mb-4 px-2">
+              What would you like to add?
+            </Text>
+
+            {ADD_OPTIONS.map((opt) => (
+              <Pressable
+                key={opt.route}
+                onPress={() => {
+                  setShowAddMenu(false)
+                  router.push(opt.route)
+                }}
+                className="flex-row items-center py-4 px-2 border-b border-gray-50 dark:border-gray-800 active:bg-gray-50 dark:active:bg-gray-800 rounded-xl"
+              >
+                <Text className="text-base text-gray-900 dark:text-white">{opt.label}</Text>
+              </Pressable>
+            ))}
+
+            <Pressable
+              onPress={() => setShowAddMenu(false)}
+              className="mt-3 py-3 items-center"
+            >
+              <Text className="text-sky-500 font-medium">Cancel</Text>
+            </Pressable>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   )
 }

--- a/mobile/app/(tabs)/stats.tsx
+++ b/mobile/app/(tabs)/stats.tsx
@@ -1,113 +1,262 @@
-import { View, Text, ScrollView } from 'react-native'
+import { useState, useMemo } from 'react'
+import { View, Text, ScrollView, Pressable } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTrips } from '../../src/hooks/useTrips'
-import { differenceInDays } from 'date-fns'
-
-export default function StatsScreen() {
-  const insets = useSafeAreaInsets()
-  const { activeTrip, trips } = useTrips()
-  const dests = activeTrip?.destinations || []
-
-  const totalNights = dests.reduce(
-    (s, d) => s + differenceInDays(new Date(d.departure), new Date(d.arrival)),
-    0
-  )
-  const countries = [...new Set(dests.map((d) => d.country))]
-  const totalTrips = trips.length
-  const activities = activeTrip?.activities || []
-
-  const statCards = [
-    { label: 'Destinations', value: dests.length, emoji: '📍' },
-    { label: 'Nights away', value: totalNights, emoji: '🌙' },
-    { label: 'Countries', value: countries.length, emoji: '🌍' },
-    { label: 'Activities', value: activities.length, emoji: '🎭' },
-  ]
-
-  return (
-    <ScrollView
-      className="flex-1 bg-gray-50 dark:bg-gray-950"
-      contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 16 }}
-    >
-      {dests.length === 0 ? (
-        <View className="flex-1 items-center justify-center py-24">
-          <Text className="text-4xl mb-3">📊</Text>
-          <Text className="text-base text-gray-500 text-center">
-            Add destinations to see your travel stats
-          </Text>
-        </View>
-      ) : (
-        <>
-          {/* Stat grid */}
-          <View className="flex-row flex-wrap gap-3 mb-6">
-            {statCards.map(({ label, value, emoji }) => (
-              <View
-                key={label}
-                className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 items-center"
-                style={{ width: '47%' }}
-              >
-                <Text className="text-2xl mb-1">{emoji}</Text>
-                <Text className="text-3xl font-bold text-sky-500">{value}</Text>
-                <Text className="text-xs text-gray-500 dark:text-gray-400 mt-1">{label}</Text>
-              </View>
-            ))}
-          </View>
-
-          {/* Countries visited */}
-          {countries.length > 0 && (
-            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
-              <Text className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                Countries visited
-              </Text>
-              <View className="flex-row flex-wrap gap-2">
-                {countries.map((country) => {
-                  const dest = dests.find((d) => d.country === country)
-                  const code = dest?.countryCode?.toLowerCase()
-                  return (
-                    <View
-                      key={country}
-                      className="flex-row items-center gap-1.5 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 rounded-full"
-                    >
-                      <Text className="text-sm">{getFlagEmoji(dest?.countryCode || '')}</Text>
-                      <Text className="text-xs text-gray-700 dark:text-gray-300">{country}</Text>
-                    </View>
-                  )
-                })}
-              </View>
-            </View>
-          )}
-
-          {/* Trip breakdown */}
-          {dests.length > 0 && (
-            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4">
-              <Text className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                Destinations
-              </Text>
-              {dests.map((dest) => {
-                const nights = differenceInDays(new Date(dest.departure), new Date(dest.arrival))
-                return (
-                  <View
-                    key={dest.id}
-                    className="flex-row items-center justify-between py-2 border-b border-gray-50 dark:border-gray-800/60 last:border-b-0"
-                  >
-                    <View className="flex-row items-center gap-2">
-                      <Text className="text-base">{getFlagEmoji(dest.countryCode)}</Text>
-                      <Text className="text-sm text-gray-900 dark:text-white">{dest.city}</Text>
-                    </View>
-                    <Text className="text-xs text-gray-500">{nights}n</Text>
-                  </View>
-                )
-              })}
-            </View>
-          )}
-        </>
-      )}
-    </ScrollView>
-  )
-}
+import {
+  getAvailableYears,
+  yearGeographicStats,
+  yearDistanceKm,
+  getFunComparisons,
+  getAchievementBadges,
+  getTravelPersonality,
+} from '../../src/utils/travelStats'
 
 function getFlagEmoji(countryCode: string): string {
   if (!countryCode || countryCode.length !== 2) return '📍'
   return [...countryCode.toUpperCase()]
     .map((c) => String.fromCodePoint(c.charCodeAt(0) + 127397))
     .join('')
+}
+
+const TIER_COLOR: Record<string, string> = {
+  bronze: '#cd7f32',
+  silver: '#a8a9ad',
+  gold: '#ffd700',
+}
+
+export default function StatsScreen() {
+  const insets = useSafeAreaInsets()
+  const { trips } = useTrips()
+
+  const availableYears = useMemo(() => getAvailableYears(trips), [trips])
+  const [selectedYear, setSelectedYear] = useState<number>(availableYears[0] ?? new Date().getFullYear())
+  const [compIdx, setCompIdx] = useState(0)
+
+  const geo = useMemo(() => yearGeographicStats(trips, selectedYear), [trips, selectedYear])
+  const distResult = useMemo(() => yearDistanceKm(trips, selectedYear), [trips, selectedYear])
+  const km = Math.round(distResult.km)
+
+  const comparisons = useMemo(() => getFunComparisons(km), [km])
+  const badges = useMemo(
+    () =>
+      getAchievementBadges({
+        km,
+        nightsAway: geo.nightsAway,
+        destinationCount: geo.destinationCount,
+        continents: geo.continents,
+        countryCodes: geo.countryCodes,
+      }),
+    [km, geo]
+  )
+  const personality = useMemo(() => getTravelPersonality(geo, distResult), [geo, distResult])
+  const earnedBadges = badges.filter((b) => b.earned)
+
+  const hasData = geo.destinationCount > 0
+
+  if (trips.length === 0) {
+    return (
+      <View className="flex-1 items-center justify-center bg-gray-50 dark:bg-gray-950 px-8">
+        <Text style={{ fontSize: 48 }} className="mb-3">📊</Text>
+        <Text className="text-base text-gray-500 dark:text-gray-400 text-center">
+          Add destinations to see your travel stats
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-gray-50 dark:bg-gray-950"
+      contentContainerStyle={{ paddingTop: 16, paddingHorizontal: 16, paddingBottom: insets.bottom + 24 }}
+    >
+      {/* ── Year picker ── */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8, marginBottom: 20 }}
+      >
+        {availableYears.map((y) => (
+          <Pressable
+            key={y}
+            onPress={() => { setSelectedYear(y); setCompIdx(0) }}
+            className={`px-4 py-2 rounded-full border ${
+              y === selectedYear
+                ? 'bg-sky-500 border-sky-500'
+                : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700'
+            }`}
+          >
+            <Text className={`text-sm font-semibold ${y === selectedYear ? 'text-white' : 'text-gray-700 dark:text-gray-300'}`}>
+              {y}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+
+      {!hasData ? (
+        <View className="items-center py-16">
+          <Text className="text-4xl mb-3">✈️</Text>
+          <Text className="text-base text-gray-500 dark:text-gray-400 text-center">
+            No trips in {selectedYear}
+          </Text>
+        </View>
+      ) : (
+        <>
+          {/* ── Stat cards ── */}
+          <View className="flex-row flex-wrap gap-3 mb-4">
+            {[
+              { label: 'km traveled', value: km > 0 ? km.toLocaleString() : '—', emoji: '✈️' },
+              { label: 'nights away', value: geo.nightsAway, emoji: '🌙' },
+              { label: 'countries', value: geo.countryCodes.length, emoji: '🌍' },
+              { label: 'destinations', value: geo.destinationCount, emoji: '📍' },
+            ].map(({ label, value, emoji }) => (
+              <View
+                key={label}
+                className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 items-center justify-center"
+                style={{ width: '47%' }}
+              >
+                <Text style={{ fontSize: 22 }} className="mb-1">{emoji}</Text>
+                <Text className="text-2xl font-bold text-sky-500">{value}</Text>
+                <Text className="text-xs text-gray-500 dark:text-gray-400 mt-1 text-center">{label}</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* ── Travel personality ── */}
+          {personality && (
+            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">
+                Your travel personality
+              </Text>
+              <View className="flex-row items-center gap-3">
+                <Text style={{ fontSize: 28 }}>{personality.emoji}</Text>
+                <View style={{ flex: 1 }}>
+                  <Text className="text-base font-semibold text-gray-900 dark:text-white">
+                    {personality.label}
+                  </Text>
+                  <Text className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                    {personality.description}
+                  </Text>
+                </View>
+              </View>
+            </View>
+          )}
+
+          {/* ── Fun comparison carousel ── */}
+          {comparisons.length > 0 && (
+            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                Fun comparison
+              </Text>
+              <View className="items-center py-2">
+                <Text style={{ fontSize: 32 }} className="mb-2">{comparisons[compIdx]?.emoji}</Text>
+                <Text className="text-sm text-gray-700 dark:text-gray-300 text-center leading-5">
+                  {comparisons[compIdx]?.text}
+                </Text>
+              </View>
+              {comparisons.length > 1 && (
+                <View className="flex-row justify-between items-center mt-3">
+                  <Pressable
+                    onPress={() => setCompIdx((i) => (i - 1 + comparisons.length) % comparisons.length)}
+                    className="w-11 h-11 items-center justify-center"
+                  >
+                    <Text className="text-sky-500 text-xl">‹</Text>
+                  </Pressable>
+                  <View className="flex-row gap-1.5">
+                    {comparisons.map((_, i) => (
+                      <View
+                        key={i}
+                        className={`h-1.5 rounded-full ${i === compIdx ? 'bg-sky-500 w-4' : 'bg-gray-200 dark:bg-gray-700 w-1.5'}`}
+                      />
+                    ))}
+                  </View>
+                  <Pressable
+                    onPress={() => setCompIdx((i) => (i + 1) % comparisons.length)}
+                    className="w-11 h-11 items-center justify-center"
+                  >
+                    <Text className="text-sky-500 text-xl">›</Text>
+                  </Pressable>
+                </View>
+              )}
+            </View>
+          )}
+
+          {/* ── Achievements ── */}
+          {earnedBadges.length > 0 && (
+            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                Achievements
+              </Text>
+              <View className="flex-row flex-wrap gap-2">
+                {badges.map((badge) => (
+                  <View
+                    key={badge.id}
+                    className={`flex-row items-center gap-1.5 px-3 py-1.5 rounded-full border ${
+                      badge.earned
+                        ? 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800'
+                        : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 opacity-40'
+                    }`}
+                  >
+                    <Text style={{ fontSize: 13 }}>{badge.emoji}</Text>
+                    <Text
+                      className={`text-xs font-medium ${badge.earned ? 'text-amber-700 dark:text-amber-400' : 'text-gray-500'}`}
+                    >
+                      {badge.label}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {/* ── Countries ── */}
+          {geo.countryCodes.length > 0 && (
+            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                Countries in {selectedYear}
+              </Text>
+              <View className="flex-row flex-wrap gap-2">
+                {geo.countryCodes.map((cc, i) => (
+                  <View
+                    key={cc}
+                    className="flex-row items-center gap-1.5 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 rounded-full"
+                  >
+                    <Text className="text-sm">{getFlagEmoji(cc)}</Text>
+                    <Text className="text-xs text-gray-700 dark:text-gray-300">{geo.countries[i]}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {/* ── Nights breakdown ── */}
+          {(geo.vacationNights > 0 || geo.businessNights > 0) && (
+            <View className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-4">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                Nights breakdown
+              </Text>
+              {geo.vacationNights > 0 && (
+                <View className="flex-row justify-between py-2 border-b border-gray-50 dark:border-gray-800">
+                  <Text className="text-sm text-gray-700 dark:text-gray-300">🏖 Vacation</Text>
+                  <Text className="text-sm font-medium text-sky-500">{geo.vacationNights} nights</Text>
+                </View>
+              )}
+              {geo.businessNights > 0 && (
+                <View className="flex-row justify-between py-2">
+                  <Text className="text-sm text-gray-700 dark:text-gray-300">💼 Business</Text>
+                  <Text className="text-sm font-medium text-violet-500">{geo.businessNights} nights</Text>
+                </View>
+              )}
+            </View>
+          )}
+
+          {/* ── Distance note ── */}
+          {distResult.approximateCount > 0 && km > 0 && (
+            <Text className="text-xs text-gray-400 dark:text-gray-600 text-center mb-2">
+              * Distance is approximate for {distResult.approximateCount} destination(s) without exact coordinates.
+            </Text>
+          )}
+        </>
+      )}
+    </ScrollView>
+  )
 }

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout() {
           <Stack.Screen name="destination-modal" options={{ presentation: 'formSheet', title: 'Destination' }} />
           <Stack.Screen name="hotel-modal" options={{ presentation: 'formSheet', title: 'Hotel' }} />
           <Stack.Screen name="activity-modal" options={{ presentation: 'formSheet', title: 'Activity' }} />
+          <Stack.Screen name="transport-modal" options={{ presentation: 'formSheet', title: 'Transport' }} />
           <Stack.Screen name="detail" options={{ presentation: 'pageSheet', headerShown: false }} />
         </Stack>
       </SafeAreaProvider>

--- a/mobile/app/activity-modal.tsx
+++ b/mobile/app/activity-modal.tsx
@@ -1,0 +1,231 @@
+import { View, Text, TextInput, Pressable, ScrollView, KeyboardAvoidingView, Platform } from 'react-native'
+import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTrips } from '../src/hooks/useTrips'
+import type { Activity } from '../src/types/trip'
+
+type ActivityType = 'restaurant' | 'attraction' | 'shopping' | 'medical'
+
+const TYPES: { value: ActivityType; label: string; emoji: string }[] = [
+  { value: 'restaurant', label: 'Restaurant', emoji: '🍴' },
+  { value: 'attraction', label: 'Attraction', emoji: '🏛' },
+  { value: 'shopping', label: 'Shopping', emoji: '🛍' },
+  { value: 'medical', label: 'Medical', emoji: '🏥' },
+]
+
+export default function ActivityModalScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const params = useLocalSearchParams()
+  const editing: Activity | null = params.editing ? JSON.parse(params.editing as string) : null
+  const presetDestId = params.destinationId as string | undefined
+
+  const { activeTrip, addActivity, updateActivity } = useTrips()
+  const destinations = activeTrip?.destinations || []
+
+  const [actType, setActType] = useState<ActivityType>(editing?.type || 'attraction')
+  const [name, setName] = useState(editing?.name || '')
+  const [date, setDate] = useState(editing?.date?.slice(0, 10) || '')
+  const [destinationId, setDestinationId] = useState(
+    editing?.destinationId || presetDestId || destinations[0]?.id || ''
+  )
+  const [address, setAddress] = useState(editing?.address || '')
+  const [notes, setNotes] = useState(editing?.notes || '')
+  const [phone, setPhone] = useState(editing?.phone || '')
+  const [website, setWebsite] = useState(editing?.website || '')
+  const [error, setError] = useState('')
+
+  const handleSave = () => {
+    if (!name.trim()) { setError('Please enter a name'); return }
+    if (!date) { setError('Please enter a date (YYYY-MM-DD)'); return }
+    if (!destinationId) { setError('Please select a destination'); return }
+
+    const actData: Omit<Activity, 'id'> = {
+      type: actType,
+      name: name.trim(),
+      date,
+      destinationId,
+      ...(address.trim() && { address: address.trim() }),
+      ...(notes.trim() && { notes: notes.trim() }),
+      ...(phone.trim() && { phone: phone.trim() }),
+      ...(website.trim() && { website: website.trim() }),
+    }
+
+    if (editing) {
+      updateActivity(editing.id, actData)
+    } else {
+      addActivity(actData)
+    }
+    router.back()
+  }
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-white dark:bg-gray-950"
+      style={{ paddingBottom: insets.bottom }}
+    >
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-4 border-b border-gray-100 dark:border-gray-800">
+        <Pressable onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2">
+          <Text className="text-sky-500 text-base font-medium">Cancel</Text>
+        </Pressable>
+        <Text className="text-base font-semibold text-gray-900 dark:text-white">
+          {editing ? 'Edit Activity' : 'Add Activity'}
+        </Text>
+        <Pressable onPress={handleSave} className="w-11 h-11 items-center justify-center -mr-2">
+          <Text className="text-sky-500 text-base font-semibold">Save</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView className="flex-1 px-4 pt-4" keyboardShouldPersistTaps="handled">
+        {/* Type */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+          Type
+        </Text>
+        <View className="flex-row flex-wrap gap-2 mb-1">
+          {TYPES.map((t) => (
+            <Pressable
+              key={t.value}
+              onPress={() => setActType(t.value)}
+              className={`px-4 py-2.5 rounded-xl border ${
+                actType === t.value
+                  ? 'bg-sky-500 border-sky-500'
+                  : 'border-gray-200 dark:border-gray-700'
+              }`}
+            >
+              <Text className={`text-sm font-medium ${actType === t.value ? 'text-white' : 'text-gray-600 dark:text-gray-300'}`}>
+                {t.emoji} {t.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        {/* Name */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Name
+        </Text>
+        <TextInput
+          value={name}
+          onChangeText={(t) => { setName(t); setError('') }}
+          placeholder={actType === 'restaurant' ? 'e.g. Jules Verne' : actType === 'attraction' ? 'e.g. Eiffel Tower' : actType === 'shopping' ? 'e.g. Le Bon Marché' : 'e.g. Dr. Smith appointment'}
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Date */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Date
+        </Text>
+        <TextInput
+          value={date}
+          onChangeText={(t) => { setDate(t); setError('') }}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          keyboardType="numbers-and-punctuation"
+          maxLength={10}
+        />
+
+        {/* Destination */}
+        {destinations.length > 1 && (
+          <>
+            <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+              Destination
+            </Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
+              {destinations.map((d) => (
+                <Pressable
+                  key={d.id}
+                  onPress={() => setDestinationId(d.id)}
+                  className={`px-3 py-2 rounded-xl border ${
+                    destinationId === d.id
+                      ? 'bg-sky-500 border-sky-500'
+                      : 'border-gray-200 dark:border-gray-700'
+                  }`}
+                >
+                  <Text className={`text-sm font-medium ${destinationId === d.id ? 'text-white' : 'text-gray-600 dark:text-gray-300'}`}>
+                    {d.city}
+                  </Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </>
+        )}
+
+        {/* Address */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Address (optional)
+        </Text>
+        <TextInput
+          value={address}
+          onChangeText={setAddress}
+          placeholder="e.g. 5 Avenue Anatole France"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Type-specific fields */}
+        {(actType === 'restaurant' || actType === 'medical') && (
+          <>
+            <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+              Phone (optional)
+            </Text>
+            <TextInput
+              value={phone}
+              onChangeText={setPhone}
+              placeholder="e.g. +33 1 45 55 61 44"
+              placeholderTextColor="#9ca3af"
+              className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+              keyboardType="phone-pad"
+            />
+          </>
+        )}
+
+        {(actType === 'attraction' || actType === 'shopping') && (
+          <>
+            <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+              Website (optional)
+            </Text>
+            <TextInput
+              value={website}
+              onChangeText={setWebsite}
+              placeholder="e.g. https://www.toureiffel.paris"
+              placeholderTextColor="#9ca3af"
+              className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+              keyboardType="url"
+              autoCapitalize="none"
+            />
+          </>
+        )}
+
+        {/* Notes */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Notes (optional)
+        </Text>
+        <TextInput
+          value={notes}
+          onChangeText={setNotes}
+          placeholder="Any notes…"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          multiline
+          numberOfLines={3}
+          textAlignVertical="top"
+        />
+
+        {error ? <Text className="text-red-500 text-sm mt-4">{error}</Text> : null}
+
+        <Pressable
+          onPress={handleSave}
+          className="bg-sky-500 rounded-2xl py-4 items-center mt-6 mb-4"
+        >
+          <Text className="text-white font-semibold text-base">
+            {editing ? 'Save changes' : 'Add activity'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/mobile/app/hotel-modal.tsx
+++ b/mobile/app/hotel-modal.tsx
@@ -1,0 +1,143 @@
+import { View, Text, TextInput, Pressable, ScrollView, KeyboardAvoidingView, Platform } from 'react-native'
+import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTrips } from '../src/hooks/useTrips'
+import type { Hotel } from '../src/types/trip'
+
+export default function HotelModalScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const params = useLocalSearchParams()
+  const editing: Hotel | null = params.editing ? JSON.parse(params.editing as string) : null
+
+  const { addHotel, updateHotel } = useTrips()
+
+  const [name, setName] = useState(editing?.name || '')
+  const [checkIn, setCheckIn] = useState(editing?.checkIn?.slice(0, 10) || '')
+  const [checkOut, setCheckOut] = useState(editing?.checkOut?.slice(0, 10) || '')
+  const [address, setAddress] = useState(editing?.address || '')
+  const [confirmationNumber, setConfirmationNumber] = useState(editing?.confirmationNumber || '')
+  const [error, setError] = useState('')
+
+  const handleSave = () => {
+    if (!name.trim()) { setError('Please enter a hotel name'); return }
+    if (!checkIn) { setError('Please enter check-in date (YYYY-MM-DD)'); return }
+    if (!checkOut) { setError('Please enter check-out date (YYYY-MM-DD)'); return }
+    if (checkIn >= checkOut) { setError('Check-out must be after check-in'); return }
+
+    const hotelData = {
+      name: name.trim(),
+      checkIn,
+      checkOut,
+      ...(address.trim() && { address: address.trim() }),
+      ...(confirmationNumber.trim() && { confirmationNumber: confirmationNumber.trim() }),
+    }
+
+    if (editing) {
+      updateHotel(editing.id, hotelData)
+    } else {
+      addHotel(hotelData)
+    }
+    router.back()
+  }
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-white dark:bg-gray-950"
+      style={{ paddingBottom: insets.bottom }}
+    >
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-4 border-b border-gray-100 dark:border-gray-800">
+        <Pressable onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2">
+          <Text className="text-sky-500 text-base font-medium">Cancel</Text>
+        </Pressable>
+        <Text className="text-base font-semibold text-gray-900 dark:text-white">
+          {editing ? 'Edit Hotel' : 'Add Hotel'}
+        </Text>
+        <Pressable onPress={handleSave} className="w-11 h-11 items-center justify-center -mr-2">
+          <Text className="text-sky-500 text-base font-semibold">Save</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView className="flex-1 px-4 pt-4" keyboardShouldPersistTaps="handled">
+        {/* Name */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+          Hotel name
+        </Text>
+        <TextInput
+          value={name}
+          onChangeText={(t) => { setName(t); setError('') }}
+          placeholder="e.g. Le Marais Hotel"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Check-in */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Check-in date
+        </Text>
+        <TextInput
+          value={checkIn}
+          onChangeText={(t) => { setCheckIn(t); setError('') }}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          keyboardType="numbers-and-punctuation"
+          maxLength={10}
+        />
+
+        {/* Check-out */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Check-out date
+        </Text>
+        <TextInput
+          value={checkOut}
+          onChangeText={(t) => { setCheckOut(t); setError('') }}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          keyboardType="numbers-and-punctuation"
+          maxLength={10}
+        />
+
+        {/* Address */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Address (optional)
+        </Text>
+        <TextInput
+          value={address}
+          onChangeText={setAddress}
+          placeholder="e.g. 5 Rue de la Paix, Paris"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Confirmation number */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Confirmation number (optional)
+        </Text>
+        <TextInput
+          value={confirmationNumber}
+          onChangeText={setConfirmationNumber}
+          placeholder="e.g. BK12345678"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          autoCapitalize="characters"
+        />
+
+        {error ? <Text className="text-red-500 text-sm mt-4">{error}</Text> : null}
+
+        <Pressable
+          onPress={handleSave}
+          className="bg-sky-500 rounded-2xl py-4 items-center mt-6 mb-4"
+        >
+          <Text className="text-white font-semibold text-base">
+            {editing ? 'Save changes' : 'Add hotel'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/mobile/app/transport-modal.tsx
+++ b/mobile/app/transport-modal.tsx
@@ -1,0 +1,200 @@
+import { View, Text, TextInput, Pressable, ScrollView, KeyboardAvoidingView, Platform } from 'react-native'
+import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTrips } from '../src/hooks/useTrips'
+import type { Transport } from '../src/types/trip'
+
+type TransportType = 'flight' | 'train' | 'bus' | 'car' | 'ferry' | 'other'
+
+const TYPES: { value: TransportType; label: string; emoji: string }[] = [
+  { value: 'flight', label: 'Flight', emoji: '✈️' },
+  { value: 'train', label: 'Train', emoji: '🚄' },
+  { value: 'bus', label: 'Bus', emoji: '🚌' },
+  { value: 'car', label: 'Car', emoji: '🚗' },
+  { value: 'ferry', label: 'Ferry', emoji: '⛴️' },
+  { value: 'other', label: 'Other', emoji: '🧳' },
+]
+
+export default function TransportModalScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const params = useLocalSearchParams()
+  const editing: Transport | null = params.editing ? JSON.parse(params.editing as string) : null
+
+  const { addTransport, updateTransport } = useTrips()
+
+  const [transType, setTransType] = useState<TransportType>(editing?.type || 'flight')
+  const [fromCity, setFromCity] = useState(editing?.fromCity || '')
+  const [toCity, setToCity] = useState(editing?.toCity || '')
+  const [departureDate, setDepartureDate] = useState(editing?.departureDate?.slice(0, 10) || '')
+  const [arrivalDate, setArrivalDate] = useState(editing?.arrivalDate?.slice(0, 10) || '')
+  const [carrier, setCarrier] = useState(editing?.carrier || '')
+  const [flightNumber, setFlightNumber] = useState(editing?.flightNumber || '')
+  const [error, setError] = useState('')
+
+  const handleSave = () => {
+    if (!fromCity.trim()) { setError('Please enter departure city'); return }
+    if (!toCity.trim()) { setError('Please enter arrival city'); return }
+    if (!departureDate) { setError('Please enter departure date (YYYY-MM-DD)'); return }
+    if (!arrivalDate) { setError('Please enter arrival date (YYYY-MM-DD)'); return }
+    if (departureDate > arrivalDate) { setError('Arrival must be on or after departure'); return }
+
+    const transportData: Omit<Transport, 'id'> = {
+      type: transType,
+      fromCity: fromCity.trim(),
+      toCity: toCity.trim(),
+      departureDate,
+      arrivalDate,
+      ...(carrier.trim() && { carrier: carrier.trim() }),
+      ...(flightNumber.trim() && { flightNumber: flightNumber.trim() }),
+    }
+
+    if (editing) {
+      updateTransport(editing.id, transportData)
+    } else {
+      addTransport(transportData)
+    }
+    router.back()
+  }
+
+  const carrierLabel =
+    transType === 'flight' ? 'Airline' :
+    transType === 'train' ? 'Train operator' :
+    transType === 'bus' ? 'Bus company' :
+    transType === 'ferry' ? 'Ferry operator' : 'Carrier'
+
+  const refLabel =
+    transType === 'flight' ? 'Flight number' : 'Booking reference'
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-white dark:bg-gray-950"
+      style={{ paddingBottom: insets.bottom }}
+    >
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-4 border-b border-gray-100 dark:border-gray-800">
+        <Pressable onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2">
+          <Text className="text-sky-500 text-base font-medium">Cancel</Text>
+        </Pressable>
+        <Text className="text-base font-semibold text-gray-900 dark:text-white">
+          {editing ? 'Edit Transport' : 'Add Transport'}
+        </Text>
+        <Pressable onPress={handleSave} className="w-11 h-11 items-center justify-center -mr-2">
+          <Text className="text-sky-500 text-base font-semibold">Save</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView className="flex-1 px-4 pt-4" keyboardShouldPersistTaps="handled">
+        {/* Type */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+          Type
+        </Text>
+        <View className="flex-row flex-wrap gap-2 mb-1">
+          {TYPES.map((t) => (
+            <Pressable
+              key={t.value}
+              onPress={() => setTransType(t.value)}
+              className={`px-4 py-2.5 rounded-xl border ${
+                transType === t.value
+                  ? 'bg-sky-500 border-sky-500'
+                  : 'border-gray-200 dark:border-gray-700'
+              }`}
+            >
+              <Text className={`text-sm font-medium ${transType === t.value ? 'text-white' : 'text-gray-600 dark:text-gray-300'}`}>
+                {t.emoji} {t.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        {/* From / To */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          From
+        </Text>
+        <TextInput
+          value={fromCity}
+          onChangeText={(t) => { setFromCity(t); setError('') }}
+          placeholder="e.g. Paris"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          To
+        </Text>
+        <TextInput
+          value={toCity}
+          onChangeText={(t) => { setToCity(t); setError('') }}
+          placeholder="e.g. Rome"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Dates */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Departure date
+        </Text>
+        <TextInput
+          value={departureDate}
+          onChangeText={(t) => { setDepartureDate(t); setError('') }}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          keyboardType="numbers-and-punctuation"
+          maxLength={10}
+        />
+
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          Arrival date
+        </Text>
+        <TextInput
+          value={arrivalDate}
+          onChangeText={(t) => { setArrivalDate(t); setError('') }}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          keyboardType="numbers-and-punctuation"
+          maxLength={10}
+        />
+
+        {/* Carrier */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          {carrierLabel} (optional)
+        </Text>
+        <TextInput
+          value={carrier}
+          onChangeText={setCarrier}
+          placeholder={transType === 'flight' ? 'e.g. Air France' : 'e.g. Trenitalia'}
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+        />
+
+        {/* Flight/booking number */}
+        <Text className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">
+          {refLabel} (optional)
+        </Text>
+        <TextInput
+          value={flightNumber}
+          onChangeText={setFlightNumber}
+          placeholder={transType === 'flight' ? 'e.g. AF1234' : 'e.g. 8XKP3Y'}
+          placeholderTextColor="#9ca3af"
+          className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-900 dark:text-white"
+          autoCapitalize="characters"
+        />
+
+        {error ? <Text className="text-red-500 text-sm mt-4">{error}</Text> : null}
+
+        <Pressable
+          onPress={handleSave}
+          className="bg-sky-500 rounded-2xl py-4 items-center mt-6 mb-4"
+        >
+          <Text className="text-white font-semibold text-base">
+            {editing ? 'Save changes' : 'Add transport'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/mobile/src/components/DetailCard.tsx
+++ b/mobile/src/components/DetailCard.tsx
@@ -25,6 +25,7 @@ interface Props {
   item: SelectedItem
   onClose: () => void
   onEdit?: () => void
+  onDelete?: () => void
 }
 
 // ── Shared helpers ─────────────────────────────────────────────────────────
@@ -417,7 +418,7 @@ function TransportCard({ transport }: { transport: Transport }) {
 
 // ── Main DetailCard ─────────────────────────────────────────────────────────
 
-export default function DetailCard({ item, onClose, onEdit }: Props) {
+export default function DetailCard({ item, onClose, onEdit, onDelete }: Props) {
   return (
     <Modal
       visible={item !== null}
@@ -510,8 +511,26 @@ export default function DetailCard({ item, onClose, onEdit }: Props) {
             paddingVertical: 16,
             borderTopWidth: 1,
             borderTopColor: '#f3f4f6',
+            flexDirection: 'row',
+            gap: 12,
           }}
         >
+          {onDelete && (
+            <Pressable
+              onPress={onDelete}
+              style={({ pressed }) => ({
+                opacity: pressed ? 0.85 : 1,
+                backgroundColor: '#fee2e2',
+                borderRadius: 12,
+                paddingVertical: 12,
+                alignItems: 'center',
+                flex: 1,
+              })}
+              accessibilityLabel="Delete"
+            >
+              <Text style={{ fontSize: 14, fontWeight: '600', color: '#ef4444' }}>Delete</Text>
+            </Pressable>
+          )}
           <Pressable
             onPress={onEdit}
             style={({ pressed }) => ({
@@ -520,6 +539,10 @@ export default function DetailCard({ item, onClose, onEdit }: Props) {
               borderRadius: 12,
               paddingVertical: 12,
               alignItems: 'center',
+              flex: onDelete ? 1 : undefined,
+              paddingHorizontal: onDelete ? undefined : 32,
+              alignSelf: onDelete ? undefined : 'stretch',
+              width: onDelete ? undefined : '100%',
             })}
             accessibilityLabel="Edit"
           >


### PR DESCRIPTION
## Summary

- **Hotel modal** — add/edit hotels with name, check-in/out dates, address, confirmation number
- **Activity modal** — type pills (restaurant/attraction/shopping/medical), name, date, destination selector, type-specific fields (phone, website)
- **Transport modal** — type pills (flight/train/bus/car/ferry/other), from/to city, departure/arrival dates, carrier, booking reference
- **"+" add menu** — tapping `+` in the header now opens a bottom sheet with 4 options (Destination, Hotel, Activity, Transport) instead of going directly to destination-modal
- **Edit all item types** — DetailCard's Edit button now navigates to the correct modal for hotel/activity/transport (previously only worked for destinations)
- **Delete with confirm** — DetailCard now shows a red Delete button alongside Edit; tap triggers an `Alert.alert` confirmation dialog
- **Full TravelStats screen** — year selector pills, distance km, travel personality type, fun comparisons carousel (paginated), achievement badges, countries list, nights breakdown (vacation vs business)

## Test plan
- [ ] Tap `+` → bottom sheet shows 4 options
- [ ] Add Hotel → hotel-modal opens, save → appears in ItineraryList
- [ ] Add Activity → activity-modal opens with type selector, save → appears as pill under destination
- [ ] Add Transport → transport-modal opens with type selector, save → appears in ItineraryList
- [ ] Tap any item → DetailCard opens with both Delete and Edit buttons
- [ ] Edit → correct modal opens pre-filled with existing data
- [ ] Delete → Alert confirmation → item removed
- [ ] Stats tab: year pills switch years; comparisons carousel arrows work; badges highlight earned ones

https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WotfgSB1AKgVYfZmzTWVEr)_